### PR TITLE
Work around undefined EIGEN_DEVICE_FUNC with Eigen 3.3~beta1-2

### DIFF
--- a/Source/Applications/SIMPLView/AboutSIMPLView.cpp
+++ b/Source/Applications/SIMPLView/AboutSIMPLView.cpp
@@ -47,6 +47,7 @@
 #include <tbb/tbb_stddef.h>
 #endif
 
+#include <Eigen/Core>
 #include <Eigen/src/Core/util/Macros.h>
 
 


### PR DESCRIPTION
This is the Eigen that is packaged with Ubuntu 16.04.  Addresses the build error:

FAILED: /usr/bin/c++  -DH5_BUILT_AS_DYNAMIC_LIB=1 -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_POSITIONING_LIB -DQT_PRINTSUPPORT_LIB -DQT_QML_LIB -DQT_QUICKWIDGETS_LIB -DQT_QUICK_LIB -DQT_SCRIPT_LIB -DQT_SVG_LIB -DQT_WEBCHANNEL_LIB -DQT_WEBENGINECORE_LIB -DQT_WEBENGINEWIDGETS_LIB -DQT_WEBENGINE_LIB -DQT_WIDGETS_LIB -DQT_XML_LIB -ISIMPLView/Applications/SIMPLView -I/home/matt/src/DREAM3D/SIMPLView/Source/Applications/SIMPLView -isystem /DREAM3D_SDK/prefix-Release/include -I/usr/include/eigen3 -isystem /DREAM3D_SDK/prefix-Release/include/QtCore -isystem /DREAM3D_SDK/prefix-Release/./mkspecs/linux-g++ -isystem /DREAM3D_SDK/prefix-Release/include/QtWidgets -isystem /DREAM3D_SDK/prefix-Release/include/QtGui -isystem /DREAM3D_SDK/prefix-Release/include/QtNetwork -isystem /DREAM3D_SDK/prefix-Release/include/QtConcurrent -isystem /DREAM3D_SDK/prefix-Release/include/QtScript -isystem /DREAM3D_SDK/prefix-Release/include/QtSvg -isystem /DREAM3D_SDK/prefix-Release/include/QtXml -isystem /DREAM3D_SDK/prefix-Release/include/QtOpenGL -isystem /DREAM3D_SDK/prefix-Release/include/QtPrintSupport -isystem /DREAM3D_SDK/prefix-Release/include/QtPositioning -isystem /DREAM3D_SDK/prefix-Release/include/QtWebEngine -isystem /DREAM3D_SDK/prefix-Release/include/QtWebEngineCore -isystem /DREAM3D_SDK/prefix-Release/include/QtQuick -isystem /DREAM3D_SDK/prefix-Release/include/QtQml -isystem /DREAM3D_SDK/prefix-Release/include/QtWebChannel -isystem /DREAM3D_SDK/prefix-Release/include/QtWebEngineWidgets -isystem /DREAM3D_SDK/prefix-Release/include/QtQuickWidgets -I/DREAM3D_SDK/prefix-Release/include/QtDBus -ISIMPLView -I/home/matt/src/DREAM3D/SIMPLView/Source -I/home/matt/src/DREAM3D/DREAM3D/Resources/OpenSourceEdition -I/.. -ISIMPLView/Applications/SIMPLView/SIMPLView -ISIMPLView/Applications -I/home/matt/src/DREAM3D/SIMPL/Source -ISIMPLView/SIMPL -I/home/matt/src/DREAM3D/SIMPL/Source/SVWidgetsLib -I/home/matt/src/DREAM3D/SIMPL/Source/SVWidgetsLib/Core -I/home/matt/src/DREAM3D/SIMPL/Source/SVWidgetsLib/Dialogs -I/home/matt/src/DREAM3D/SIMPL/Source/SVWidgetsLib/FilterParameterWidgets -I/home/matt/src/DREAM3D/SIMPL/Source/SVWidgetsLib/QtSupport -I/home/matt/src/DREAM3D/SIMPL/Source/SVWidgetsLib/Widgets -ISIMPLView/SIMPL/SVWidgetsLib -ISIMPLView/SIMPL/SVWidgetsLib/Core -ISIMPLView/SIMPL/SVWidgetsLib/Dialogs -ISIMPLView/SIMPL/SVWidgetsLib/FilterParameterWidgets -ISIMPLView/SIMPL/SVWidgetsLib/QtSupport -ISIMPLView/SIMPL/SVWidgetsLib/Widgets -ISIMPLView/Applications/SIMPLView/__/Common -std=c++11  -fmessage-length=0 -O3 -DNDEBUG   -fPIC -fPIC -MD -MT SIMPLView/Applications/SIMPLView/CMakeFiles/DREAM3D.dir/AboutSIMPLView.cpp.o -MF SIMPLView/Applications/SIMPLView/CMakeFiles/DREAM3D.dir/AboutSIMPLView.cpp.o.d -o SIMPLView/Applications/SIMPLView/CMakeFiles/DREAM3D.dir/AboutSIMPLView.cpp.o -c /home/matt/src/DREAM3D/SIMPLView/Source/Applications/SIMPLView/AboutSIMPLView.cpp
In file included from /home/matt/src/DREAM3D/SIMPLView/Source/Applications/SIMPLView/AboutSIMPLView.cpp:50:0:
/usr/include/eigen3/Eigen/src/Core/util/Macros.h:549:26: error: ‘EIGEN_DEVICE_FUNC’ does not name a type
     template<typename T> EIGEN_DEVICE_FUNC void ignore_unused_variable(const T&) {}
                          ^
