### PR TITLE
Hide the issues and standard output dock widgets when there are no errors

### DIFF
--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -147,6 +147,14 @@ SIMPLView_UI::SIMPLView_UI(QWidget* parent)
 
   // Read various settings
   readSettings();
+  if(HideDockSetting::OnError == m_HideErrorTable)
+  {
+    issuesDockWidget->setHidden(true);
+  }
+  if(HideDockSetting::OnError == m_HideStdOutput)
+  {
+    stdOutDockWidget->setHidden(true);
+  }
 
   // Set window modified to false
   setWindowModified(false);
@@ -341,10 +349,12 @@ void SIMPLView_UI::readSettings()
 
   prefs->beginGroup("Issues Dock Widget");
   readDockWidgetSettings(prefs.data(), issuesDockWidget);
+  readHideDockSettings(prefs.data(), m_HideErrorTable);
   prefs->endGroup();
 
   prefs->beginGroup("Standard Output Dock Widget");
   readDockWidgetSettings(prefs.data(), stdOutDockWidget);
+  readHideDockSettings(prefs.data(), m_HideStdOutput);
   prefs->endGroup();
 
   prefs->endGroup();
@@ -401,6 +411,16 @@ void SIMPLView_UI::readDockWidgetSettings(QtSSettings* prefs, QDockWidget* dw)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+void SIMPLView_UI::readHideDockSettings(QtSSettings* prefs, HideDockSetting& value)
+{
+  int showError = static_cast<int>(HideDockSetting::OnError);
+  int hideDockSetting = prefs->value("HideDockSetting", QVariant(showError)).toInt();
+  value = static_cast<HideDockSetting>(hideDockSetting);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void SIMPLView_UI::readVersionSettings(QtSSettings* prefs)
 {
 }
@@ -421,10 +441,12 @@ void SIMPLView_UI::writeSettings()
 
   prefs->beginGroup("Issues Dock Widget");
   writeDockWidgetSettings(prefs.data(), issuesDockWidget);
+  writeHideDockSettings(prefs.data(), m_HideErrorTable);
   prefs->endGroup();
 
   prefs->beginGroup("Standard Output Dock Widget");
   writeDockWidgetSettings(prefs.data(), stdOutDockWidget);
+  writeHideDockSettings(prefs.data(), m_HideStdOutput);
   prefs->endGroup();
 
   prefs->endGroup();
@@ -466,6 +488,15 @@ void SIMPLView_UI::writeWindowSettings(QtSSettings* prefs)
 void SIMPLView_UI::writeDockWidgetSettings(QtSSettings* prefs, QDockWidget* dw)
 {
   prefs->setValue(dw->objectName(), dw->isHidden());
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void SIMPLView_UI::writeHideDockSettings(QtSSettings* prefs, HideDockSetting value)
+{
+  int valuei = static_cast<int>(value);
+  prefs->setValue("HideDockSetting", valuei);
 }
 
 // -----------------------------------------------------------------------------
@@ -559,6 +590,7 @@ void SIMPLView_UI::setupGui()
   m_StatusBar->setButtonAction(dataBrowserDockWidget, StatusBarWidget::Button::DataStructure);
 
   connect(issuesWidget, SIGNAL(tableHasErrors(bool)), m_StatusBar, SLOT(issuesTableHasErrors(bool)));
+  connect(issuesWidget, SIGNAL(tableHasErrors(bool)), this, SLOT(issuesTableHasErrors(bool)));
   connect(issuesWidget, SIGNAL(showTable(bool)), issuesDockWidget, SLOT(setVisible(bool)));
 }
 
@@ -1303,6 +1335,22 @@ void SIMPLView_UI::clearFilterInputWidget()
 void SIMPLView_UI::markDocumentAsDirty()
 {
   setWindowModified(true);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void SIMPLView_UI::issuesTableHasErrors(bool hasErrors)
+{
+  if(HideDockSetting::OnError == m_HideErrorTable)
+  {
+    issuesDockWidget->setHidden(!hasErrors);
+  }
+
+  if(HideDockSetting::OnError == m_HideStdOutput)
+  {
+    stdOutDockWidget->setHidden(!hasErrors);
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -89,6 +89,12 @@ class SIMPLView_UI : public QMainWindow, private Ui::SIMPLView_UI
     Q_OBJECT
 
   public:
+    enum class HideDockSetting : int
+    {
+      OnError = 0,
+      Ignore
+    };
+
     SIMPLView_UI(QWidget* parent = 0);
     virtual ~SIMPLView_UI();
 
@@ -255,6 +261,12 @@ class SIMPLView_UI : public QMainWindow, private Ui::SIMPLView_UI
     */
     void markDocumentAsDirty();
 
+    /**
+    * @brief issuesTableHasErrors
+    * @param hasErrors
+    */
+    void issuesTableHasErrors(bool hasErrors);
+
     // Our Signals that we can emit custom for this class
   signals:
 
@@ -351,11 +363,25 @@ class SIMPLView_UI : public QMainWindow, private Ui::SIMPLView_UI
     void readDockWidgetSettings(QtSSettings* prefs, QDockWidget* dw);
 
     /**
+    * @brief SIMPLView_UI::setupDockWidget
+    * @param prefs
+    * @param value
+    */
+    void readHideDockSettings(QtSSettings* prefs, HideDockSetting& value);
+
+    /**
      * @brief writeDockWidgetSettings
      * @param prefs
      * @param dw
      */
     void writeDockWidgetSettings(QtSSettings* prefs, QDockWidget* dw);
+
+    /**
+    * @brief writeHideDockSettings
+    * @param prefs
+    * @param value
+    */
+    void writeHideDockSettings(QtSSettings* prefs, HideDockSetting value);
 
     /**
      * @brief Checks the currently open file for changes that need to be saved
@@ -390,6 +416,9 @@ class SIMPLView_UI : public QMainWindow, private Ui::SIMPLView_UI
 
     bool                                  m_ShowFilterWidgetDeleteDialog;
     bool                                  m_ShouldRestart = false;
+
+    HideDockSetting                       m_HideErrorTable = HideDockSetting::OnError;
+    HideDockSetting                       m_HideStdOutput = HideDockSetting::OnError;
 
     void cleanupPipeline();
 


### PR DESCRIPTION
Added a preference option for the issuesDockWidget and stdOutDockWidget that hides them when all errors are cleared and shows them when there is an error in the pipeline. Both dock widgets have their own preference variable that is read and written alongside the other preferences.  The current possible values for this variable are OnError and Ignore.  Ignore retains the previous behavior of not changing the visibility when an error is created or cleared.  OnError shows the target dock widget when an error is found and hides the dock widget when all errors are cleared.  The default value is OnError, but there is not a way for the user to change their preference.

fixes #21