### PR TITLE
Updated the Show / Hide on Error preference values

### DIFF
--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -1356,14 +1356,12 @@ void SIMPLView_UI::issuesTableHasErrors(bool hasErrors, int errCount, int warnCo
 {
   Q_UNUSED(errCount)
   Q_UNUSED(warnCount)
-  if(HideDockSetting::OnError == m_HideErrorTable
-    || HideDockSetting::OnStatusAndError == m_HideErrorTable)
+  if(HideDockSetting::OnError == m_HideErrorTable || HideDockSetting::OnStatusAndError == m_HideErrorTable)
   {
     issuesDockWidget->setVisible(hasErrors);
   }
 
-  if(HideDockSetting::OnError == m_HideStdOutput
-    || HideDockSetting::OnStatusAndError == m_HideStdOutput)
+  if(HideDockSetting::OnError == m_HideStdOutput || HideDockSetting::OnStatusAndError == m_HideStdOutput)
   {
     stdOutDockWidget->setVisible(hasErrors);
   }

--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -970,15 +970,6 @@ void SIMPLView_UI::processPipelineMessage(const PipelineMessage& msg)
     if(HideDockSetting::OnStatusAndError == m_HideStdOutput)
     {
       stdOutDockWidget->setVisible(true);
-
-#if 0
-      if(stdOutDockWidget->isVisible() == false)
-      {
-        // This does not actually do anything.
-        // Use stdOutDockWidget->setVisible(bool) instead
-        stdOutDockWidget->toggleViewAction()->toggle();
-      }
-#endif
     }
 
     // Allow status messages to open the issuesDockWidget as well

--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -966,14 +966,26 @@ void SIMPLView_UI::processPipelineMessage(const PipelineMessage& msg)
       }
     }
 
-#if 0
-    if(stdOutDockWidget->isVisible() == false)
+    // Allow status messages to open the standard output widget
+    if(HideDockSetting::OnStatusAndError == m_HideStdOutput)
     {
-      // This does not actually do anything.
-      // Use stdOutDockWidget->setVisible(bool) instead
-      stdOutDockWidget->toggleViewAction()->toggle();
-    }
+      stdOutDockWidget->setVisible(true);
+
+#if 0
+      if(stdOutDockWidget->isVisible() == false)
+      {
+        // This does not actually do anything.
+        // Use stdOutDockWidget->setVisible(bool) instead
+        stdOutDockWidget->toggleViewAction()->toggle();
+      }
 #endif
+    }
+
+    // Allow status messages to open the issuesDockWidget as well
+    if(HideDockSetting::OnStatusAndError == m_HideErrorTable)
+    {
+      issuesDockWidget->setVisible(true);
+    }
 
     QString text = "<span style=\" color:#000000;\" >";
     text.append(msg.getText());
@@ -1344,12 +1356,14 @@ void SIMPLView_UI::issuesTableHasErrors(bool hasErrors, int errCount, int warnCo
 {
   Q_UNUSED(errCount)
   Q_UNUSED(warnCount)
-  if(HideDockSetting::OnError == m_HideErrorTable)
+  if(HideDockSetting::OnError == m_HideErrorTable
+    || HideDockSetting::OnStatusAndError == m_HideErrorTable)
   {
     issuesDockWidget->setVisible(hasErrors);
   }
 
-  if(HideDockSetting::OnError == m_HideStdOutput)
+  if(HideDockSetting::OnError == m_HideStdOutput
+    || HideDockSetting::OnStatusAndError == m_HideStdOutput)
   {
     stdOutDockWidget->setVisible(hasErrors);
   }

--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -408,8 +408,8 @@ void SIMPLView_UI::readDockWidgetSettings(QtSSettings* prefs, QDockWidget* dw)
 // -----------------------------------------------------------------------------
 void SIMPLView_UI::readHideDockSettings(QtSSettings* prefs, HideDockSetting& value)
 {
-  int showError = static_cast<int>(HideDockSetting::OnError);
-  int hideDockSetting = prefs->value("HideDockSetting", QVariant(showError)).toInt();
+  int showError = static_cast<int>(HideDockSetting::Ignore);
+  int hideDockSetting = prefs->value("Show / Hide On Error", QVariant(showError)).toInt();
   value = static_cast<HideDockSetting>(hideDockSetting);
 }
 
@@ -486,7 +486,7 @@ void SIMPLView_UI::writeDockWidgetSettings(QtSSettings* prefs, QDockWidget* dw)
 void SIMPLView_UI::writeHideDockSettings(QtSSettings* prefs, HideDockSetting value)
 {
   int valuei = static_cast<int>(value);
-  prefs->setValue("HideDockSetting", valuei);
+  prefs->setValue("Show / Hide On Error", valuei);
 }
 
 // -----------------------------------------------------------------------------
@@ -966,10 +966,14 @@ void SIMPLView_UI::processPipelineMessage(const PipelineMessage& msg)
       }
     }
 
+#if 0
     if(stdOutDockWidget->isVisible() == false)
     {
+      // This does not actually do anything.
+      // Use stdOutDockWidget->setVisible(bool) instead
       stdOutDockWidget->toggleViewAction()->toggle();
     }
+#endif
 
     QString text = "<span style=\" color:#000000;\" >";
     text.append(msg.getText());
@@ -1342,12 +1346,12 @@ void SIMPLView_UI::issuesTableHasErrors(bool hasErrors, int errCount, int warnCo
   Q_UNUSED(warnCount)
   if(HideDockSetting::OnError == m_HideErrorTable)
   {
-    issuesDockWidget->setHidden(!hasErrors);
+    issuesDockWidget->setVisible(hasErrors);
   }
 
   if(HideDockSetting::OnError == m_HideStdOutput)
   {
-    stdOutDockWidget->setHidden(!hasErrors);
+    stdOutDockWidget->setVisible(hasErrors);
   }
 }
 

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -92,8 +92,8 @@ class SIMPLView_UI : public QMainWindow, private Ui::SIMPLView_UI
   public:
     enum class HideDockSetting : int
     {
-      OnError = 0,
-      Ignore
+      Ignore = 0,
+      OnError = 1
     };
 
     SIMPLView_UI(QWidget* parent = 0);
@@ -418,8 +418,8 @@ class SIMPLView_UI : public QMainWindow, private Ui::SIMPLView_UI
     bool                                  m_ShowFilterWidgetDeleteDialog;
     bool                                  m_ShouldRestart = false;
 
-    HideDockSetting                       m_HideErrorTable = HideDockSetting::OnError;
-    HideDockSetting                       m_HideStdOutput = HideDockSetting::OnError;
+    HideDockSetting                       m_HideErrorTable = HideDockSetting::Ignore;
+    HideDockSetting                       m_HideStdOutput = HideDockSetting::Ignore;
 
     void cleanupPipeline();
 

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -93,7 +93,8 @@ class SIMPLView_UI : public QMainWindow, private Ui::SIMPLView_UI
     enum class HideDockSetting : int
     {
       Ignore = 0,
-      OnError = 1
+      OnError = 1,
+      OnStatusAndError = 2
     };
 
     SIMPLView_UI(QWidget* parent = 0);


### PR DESCRIPTION
Updated the preference values to make more sense when reading the preferences file and changed the value key to better describe what the value means.  Word of warning for future changes: calling toggleViewAction()->toggle() on a QDockWidget does not change the widget's visibility. toggleViewAction()->setChecked(bool) should be checked before continued use. QDockWidget::setVisible(bool) and QDockWidget::setHidden(bool) do work and fulfill the intended purpose.  To complete the fix, changes in SVWidgetsLib need to also be integrated where a signal variable was hardcoded to false.