### PR TITLE
Feature/Data Structure Double-Click

### DIFF
--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -1088,6 +1088,7 @@ void SIMPLView_UI::setFilterInputWidget(FilterInputWidget* widget)
   connect(widget, SIGNAL(endViewPaths()), getDataStructureWidget(), SLOT(clearViewRequirements()), Qt::ConnectionType::UniqueConnection);
   connect(getDataStructureWidget(), SIGNAL(filterPath(DataArrayPath)), widget, SIGNAL(filterPath(DataArrayPath)), Qt::ConnectionType::UniqueConnection);
   connect(getDataStructureWidget(), SIGNAL(endPathFiltering()), widget, SIGNAL(endPathFiltering()), Qt::ConnectionType::UniqueConnection);
+  connect(getDataStructureWidget(), SIGNAL(applyPathToFilteringParameter(DataArrayPath)), widget, SIGNAL(applyPathToFilteringParameter(DataArrayPath)));
 
   emit widget->endPathFiltering();
 


### PR DESCRIPTION
Added support for the user to set a DataArrayPath from the DataStructureWidget to a DataArrayPathSelectionWidget by double-clicking on paths in the DataStructureWidget.  Only paths that meet the requirements for the current DataArrayPathSelectionWidget can be applied in this way.
