### PR TITLE
Feature/UX DataArrayPathSelectionWidgets

### DIFF
--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -1039,6 +1039,12 @@ void SIMPLView_UI::setFilterInputWidget(FilterInputWidget* widget)
     return;
   }
 
+  if(m_FilterInputWidget)
+  {
+    emit m_FilterInputWidget->endPathFiltering();
+    emit m_FilterInputWidget->endViewPaths();
+  }
+
   // Clear the filter input widget
   clearFilterInputWidget();
 
@@ -1055,6 +1061,7 @@ void SIMPLView_UI::setFilterInputWidget(FilterInputWidget* widget)
 
   // Set the widget into the frame
   m_Ui->fiwFrameVLayout->addWidget(widget);
+  m_FilterInputWidget = widget;
   widget->show();
 }
 
@@ -1073,6 +1080,8 @@ void SIMPLView_UI::clearFilterInputWidget()
       w->setParent(nullptr);
     }
   }
+
+  m_FilterInputWidget = nullptr;
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -312,6 +312,8 @@ class SIMPLView_UI : public QMainWindow
     HideDockSetting                         m_HideErrorTable = HideDockSetting::Ignore;
     HideDockSetting                         m_HideStdOutput = HideDockSetting::Ignore;
 
+    FilterInputWidget*                      m_FilterInputWidget = nullptr;
+
     QMenu*                                  m_MenuFile = nullptr;
     QMenu*                                  m_MenuEdit = nullptr;
     QMenu*                                  m_MenuView = nullptr;


### PR DESCRIPTION
SIMPLView_UI now keeps track of its current FilterInputWidget so that changing the FilterInputWidget can clear any styling applied when filtering DataArrayPaths caused by DataArrayPathSelectionWidget and the DataBrowser.