### PR TITLE
Update all classes to properly implement constructors and assignment operators.

### DIFF
--- a/Source/DevHelper/AddFilterParameter.h
+++ b/Source/DevHelper/AddFilterParameter.h
@@ -80,7 +80,10 @@ class AddFilterParameter : public QWidget, public Ui::AddFilterParameter
     bool filledOutCheck();
     bool filledOutCheck_NoVarName();
 
-    AddFilterParameter(const AddFilterParameter&);    // Copy Constructor Not Implemented
-    void operator=(const AddFilterParameter&);        // Move assignment Not Implemented
+  public:
+    AddFilterParameter(const AddFilterParameter&) = delete;            // Copy Constructor Not Implemented
+    AddFilterParameter(AddFilterParameter&&) = delete;                 // Move Constructor Not Implemented
+    AddFilterParameter& operator=(const AddFilterParameter&) = delete; // Copy Assignment Not Implemented
+    AddFilterParameter& operator=(AddFilterParameter&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/AttributeMatrixCreationWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/AttributeMatrixCreationWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class AttributeMatrixCreationWidgetCodeGenerator : public FPCodeGenerator
   protected:
     AttributeMatrixCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     AttributeMatrixCreationWidgetCodeGenerator(const AttributeMatrixCreationWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AttributeMatrixCreationWidgetCodeGenerator&) = delete;                             // Move assignment Not Implemented
+    AttributeMatrixCreationWidgetCodeGenerator(AttributeMatrixCreationWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    AttributeMatrixCreationWidgetCodeGenerator& operator=(const AttributeMatrixCreationWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    AttributeMatrixCreationWidgetCodeGenerator& operator=(AttributeMatrixCreationWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/AttributeMatrixSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/AttributeMatrixSelectionWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class AttributeMatrixSelectionWidgetCodeGenerator : public FPCodeGenerator
   protected:
     AttributeMatrixSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     AttributeMatrixSelectionWidgetCodeGenerator(const AttributeMatrixSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AttributeMatrixSelectionWidgetCodeGenerator&) = delete;                              // Move assignment Not Implemented
+    AttributeMatrixSelectionWidgetCodeGenerator(AttributeMatrixSelectionWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    AttributeMatrixSelectionWidgetCodeGenerator& operator=(const AttributeMatrixSelectionWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    AttributeMatrixSelectionWidgetCodeGenerator& operator=(AttributeMatrixSelectionWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/AxisAngleWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/AxisAngleWidgetCodeGenerator.h
@@ -66,8 +66,10 @@ class AxisAngleWidgetCodeGenerator : public FPCodeGenerator
   protected:
     AxisAngleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     AxisAngleWidgetCodeGenerator(const AxisAngleWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AxisAngleWidgetCodeGenerator&) = delete;               // Move assignment Not Implemented
+    AxisAngleWidgetCodeGenerator(AxisAngleWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    AxisAngleWidgetCodeGenerator& operator=(const AxisAngleWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    AxisAngleWidgetCodeGenerator& operator=(AxisAngleWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/BooleanWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/BooleanWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class BooleanWidgetCodeGenerator : public FPCodeGenerator
   protected:
     BooleanWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     BooleanWidgetCodeGenerator(const BooleanWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const BooleanWidgetCodeGenerator&) = delete;             // Move assignment Not Implemented
+    BooleanWidgetCodeGenerator(BooleanWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    BooleanWidgetCodeGenerator& operator=(const BooleanWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    BooleanWidgetCodeGenerator& operator=(BooleanWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/ChoiceWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ChoiceWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class ChoiceWidgetCodeGenerator : public FPCodeGenerator
   protected:
     ChoiceWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     ChoiceWidgetCodeGenerator(const ChoiceWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ChoiceWidgetCodeGenerator&) = delete;            // Move assignment Not Implemented
+    ChoiceWidgetCodeGenerator(ChoiceWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    ChoiceWidgetCodeGenerator& operator=(const ChoiceWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    ChoiceWidgetCodeGenerator& operator=(ChoiceWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/CodeGenFactory.h
+++ b/Source/DevHelper/CodeGenerators/CodeGenFactory.h
@@ -55,8 +55,10 @@ class CodeGenFactory
   protected:
     CodeGenFactory();
 
-  private:
+  public:
     CodeGenFactory(const CodeGenFactory&) = delete; // Copy Constructor Not Implemented
-    void operator=(const CodeGenFactory&) = delete; // Move assignment Not Implemented
+    CodeGenFactory(CodeGenFactory&&) = delete;      // Move Constructor Not Implemented
+    CodeGenFactory& operator=(const CodeGenFactory&) = delete; // Copy Assignment Not Implemented
+    CodeGenFactory& operator=(CodeGenFactory&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/ComparisonSelectionAdvancedWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ComparisonSelectionAdvancedWidgetCodeGenerator.h
@@ -66,8 +66,10 @@ class ComparisonSelectionAdvancedWidgetCodeGenerator : public FPCodeGenerator
   protected:
     ComparisonSelectionAdvancedWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     ComparisonSelectionAdvancedWidgetCodeGenerator(const ComparisonSelectionAdvancedWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ComparisonSelectionAdvancedWidgetCodeGenerator&) = delete;                                 // Move assignment Not Implemented
+    ComparisonSelectionAdvancedWidgetCodeGenerator(ComparisonSelectionAdvancedWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    ComparisonSelectionAdvancedWidgetCodeGenerator& operator=(const ComparisonSelectionAdvancedWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    ComparisonSelectionAdvancedWidgetCodeGenerator& operator=(ComparisonSelectionAdvancedWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/ComparisonSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ComparisonSelectionWidgetCodeGenerator.h
@@ -66,8 +66,10 @@ class ComparisonSelectionWidgetCodeGenerator : public FPCodeGenerator
   protected:
     ComparisonSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     ComparisonSelectionWidgetCodeGenerator(const ComparisonSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ComparisonSelectionWidgetCodeGenerator&) = delete;                         // Move assignment Not Implemented
+    ComparisonSelectionWidgetCodeGenerator(ComparisonSelectionWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    ComparisonSelectionWidgetCodeGenerator& operator=(const ComparisonSelectionWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    ComparisonSelectionWidgetCodeGenerator& operator=(ComparisonSelectionWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/ConstrainedDoubleWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ConstrainedDoubleWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class ConstrainedDoubleWidgetCodeGenerator : public FPCodeGenerator
   protected:
     ConstrainedDoubleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     ConstrainedDoubleWidgetCodeGenerator(const ConstrainedDoubleWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ConstrainedDoubleWidgetCodeGenerator&) = delete;                       // Move assignment Not Implemented
+    ConstrainedDoubleWidgetCodeGenerator(ConstrainedDoubleWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    ConstrainedDoubleWidgetCodeGenerator& operator=(const ConstrainedDoubleWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    ConstrainedDoubleWidgetCodeGenerator& operator=(ConstrainedDoubleWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/ConstrainedIntWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ConstrainedIntWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class ConstrainedIntWidgetCodeGenerator : public FPCodeGenerator
   protected:
     ConstrainedIntWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     ConstrainedIntWidgetCodeGenerator(const ConstrainedIntWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ConstrainedIntWidgetCodeGenerator&) = delete;                    // Move assignment Not Implemented
+    ConstrainedIntWidgetCodeGenerator(ConstrainedIntWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    ConstrainedIntWidgetCodeGenerator& operator=(const ConstrainedIntWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    ConstrainedIntWidgetCodeGenerator& operator=(ConstrainedIntWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DataArrayCreationWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataArrayCreationWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class DataArrayCreationWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DataArrayCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DataArrayCreationWidgetCodeGenerator(const DataArrayCreationWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataArrayCreationWidgetCodeGenerator&) = delete;                       // Move assignment Not Implemented
+    DataArrayCreationWidgetCodeGenerator(DataArrayCreationWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DataArrayCreationWidgetCodeGenerator& operator=(const DataArrayCreationWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DataArrayCreationWidgetCodeGenerator& operator=(DataArrayCreationWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DataArraySelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataArraySelectionWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class DataArraySelectionWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DataArraySelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DataArraySelectionWidgetCodeGenerator(const DataArraySelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataArraySelectionWidgetCodeGenerator&) = delete;                        // Move assignment Not Implemented
+    DataArraySelectionWidgetCodeGenerator(DataArraySelectionWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DataArraySelectionWidgetCodeGenerator& operator=(const DataArraySelectionWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DataArraySelectionWidgetCodeGenerator& operator=(DataArraySelectionWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DataContainerArrayProxyWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerArrayProxyWidgetCodeGenerator.h
@@ -65,8 +65,10 @@ class DataContainerArrayProxyWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DataContainerArrayProxyWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DataContainerArrayProxyWidgetCodeGenerator(const DataContainerArrayProxyWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerArrayProxyWidgetCodeGenerator&) = delete;                             // Move assignment Not Implemented
+    DataContainerArrayProxyWidgetCodeGenerator(DataContainerArrayProxyWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DataContainerArrayProxyWidgetCodeGenerator& operator=(const DataContainerArrayProxyWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DataContainerArrayProxyWidgetCodeGenerator& operator=(DataContainerArrayProxyWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DataContainerCreationWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerCreationWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class DataContainerCreationWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DataContainerCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DataContainerCreationWidgetCodeGenerator(const DataContainerCreationWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerCreationWidgetCodeGenerator&) = delete;                           // Move assignment Not Implemented
+    DataContainerCreationWidgetCodeGenerator(DataContainerCreationWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DataContainerCreationWidgetCodeGenerator& operator=(const DataContainerCreationWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DataContainerCreationWidgetCodeGenerator& operator=(DataContainerCreationWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DataContainerReaderWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerReaderWidgetCodeGenerator.h
@@ -66,8 +66,10 @@ class DataContainerReaderWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DataContainerReaderWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DataContainerReaderWidgetCodeGenerator(const DataContainerReaderWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerReaderWidgetCodeGenerator&) = delete;                         // Move assignment Not Implemented
+    DataContainerReaderWidgetCodeGenerator(DataContainerReaderWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DataContainerReaderWidgetCodeGenerator& operator=(const DataContainerReaderWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DataContainerReaderWidgetCodeGenerator& operator=(DataContainerReaderWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DataContainerSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerSelectionWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class DataContainerSelectionWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DataContainerSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DataContainerSelectionWidgetCodeGenerator(const DataContainerSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DataContainerSelectionWidgetCodeGenerator&) = delete;                            // Move assignment Not Implemented
+    DataContainerSelectionWidgetCodeGenerator(DataContainerSelectionWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DataContainerSelectionWidgetCodeGenerator& operator=(const DataContainerSelectionWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DataContainerSelectionWidgetCodeGenerator& operator=(DataContainerSelectionWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DoubleWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DoubleWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class DoubleWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DoubleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DoubleWidgetCodeGenerator(const DoubleWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DoubleWidgetCodeGenerator&) = delete;            // Move assignment Not Implemented
+    DoubleWidgetCodeGenerator(DoubleWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DoubleWidgetCodeGenerator& operator=(const DoubleWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DoubleWidgetCodeGenerator& operator=(DoubleWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DynamicChoiceWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DynamicChoiceWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class DynamicChoiceWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DynamicChoiceWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DynamicChoiceWidgetCodeGenerator(const DynamicChoiceWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DynamicChoiceWidgetCodeGenerator&) = delete;                   // Move assignment Not Implemented
+    DynamicChoiceWidgetCodeGenerator(DynamicChoiceWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DynamicChoiceWidgetCodeGenerator& operator=(const DynamicChoiceWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DynamicChoiceWidgetCodeGenerator& operator=(DynamicChoiceWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/DynamicTableWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DynamicTableWidgetCodeGenerator.h
@@ -66,8 +66,10 @@ class DynamicTableWidgetCodeGenerator : public FPCodeGenerator
   protected:
     DynamicTableWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     DynamicTableWidgetCodeGenerator(const DynamicTableWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const DynamicTableWidgetCodeGenerator&) = delete;                  // Move assignment Not Implemented
+    DynamicTableWidgetCodeGenerator(DynamicTableWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    DynamicTableWidgetCodeGenerator& operator=(const DynamicTableWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    DynamicTableWidgetCodeGenerator& operator=(DynamicTableWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/FPCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FPCodeGenerator.h
@@ -92,7 +92,10 @@ class FPCodeGenerator
     QString m_Category;
     QString m_InitValue;
 
+  public:
     FPCodeGenerator(const FPCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FPCodeGenerator&) = delete;  // Move assignment Not Implemented
+    FPCodeGenerator(FPCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    FPCodeGenerator& operator=(const FPCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    FPCodeGenerator& operator=(FPCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/FileListInfoWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FileListInfoWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class FileListInfoWidgetCodeGenerator : public FPCodeGenerator
   protected:
     FileListInfoWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     FileListInfoWidgetCodeGenerator(const FileListInfoWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FileListInfoWidgetCodeGenerator&) = delete;                  // Move assignment Not Implemented
+    FileListInfoWidgetCodeGenerator(FileListInfoWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    FileListInfoWidgetCodeGenerator& operator=(const FileListInfoWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    FileListInfoWidgetCodeGenerator& operator=(FileListInfoWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/FloatVec2WidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FloatVec2WidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class FloatVec2WidgetCodeGenerator : public FPCodeGenerator
   protected:
     FloatVec2WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     FloatVec2WidgetCodeGenerator(const FloatVec2WidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FloatVec2WidgetCodeGenerator&) = delete;               // Move assignment Not Implemented
+    FloatVec2WidgetCodeGenerator(FloatVec2WidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    FloatVec2WidgetCodeGenerator& operator=(const FloatVec2WidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    FloatVec2WidgetCodeGenerator& operator=(FloatVec2WidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/FloatVec3WidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FloatVec3WidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class FloatVec3WidgetCodeGenerator : public FPCodeGenerator
   protected:
     FloatVec3WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     FloatVec3WidgetCodeGenerator(const FloatVec3WidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FloatVec3WidgetCodeGenerator&) = delete;               // Move assignment Not Implemented
+    FloatVec3WidgetCodeGenerator(FloatVec3WidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    FloatVec3WidgetCodeGenerator& operator=(const FloatVec3WidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    FloatVec3WidgetCodeGenerator& operator=(FloatVec3WidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/FloatWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FloatWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class FloatWidgetCodeGenerator : public FPCodeGenerator
   protected:
     FloatWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     FloatWidgetCodeGenerator(const FloatWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FloatWidgetCodeGenerator&) = delete;           // Move assignment Not Implemented
+    FloatWidgetCodeGenerator(FloatWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    FloatWidgetCodeGenerator& operator=(const FloatWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    FloatWidgetCodeGenerator& operator=(FloatWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/FourthOrderPolynomialWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FourthOrderPolynomialWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class FourthOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
   protected:
     FourthOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     FourthOrderPolynomialWidgetCodeGenerator(const FourthOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const FourthOrderPolynomialWidgetCodeGenerator&) = delete;                           // Move assignment Not Implemented
+    FourthOrderPolynomialWidgetCodeGenerator(FourthOrderPolynomialWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    FourthOrderPolynomialWidgetCodeGenerator& operator=(const FourthOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    FourthOrderPolynomialWidgetCodeGenerator& operator=(FourthOrderPolynomialWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/GenerateColorTableWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/GenerateColorTableWidgetCodeGenerator.h
@@ -66,8 +66,10 @@ class GenerateColorTableWidgetCodeGenerator : public FPCodeGenerator
   protected:
     GenerateColorTableWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     GenerateColorTableWidgetCodeGenerator(const GenerateColorTableWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const GenerateColorTableWidgetCodeGenerator&) = delete;                        // Move assignment Not Implemented
+    GenerateColorTableWidgetCodeGenerator(GenerateColorTableWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    GenerateColorTableWidgetCodeGenerator& operator=(const GenerateColorTableWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    GenerateColorTableWidgetCodeGenerator& operator=(GenerateColorTableWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/InputFileWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/InputFileWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class InputFileWidgetCodeGenerator : public FPCodeGenerator
   protected:
     InputFileWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     InputFileWidgetCodeGenerator(const InputFileWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const InputFileWidgetCodeGenerator&) = delete;               // Move assignment Not Implemented
+    InputFileWidgetCodeGenerator(InputFileWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    InputFileWidgetCodeGenerator& operator=(const InputFileWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    InputFileWidgetCodeGenerator& operator=(InputFileWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/InputPathWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/InputPathWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class InputPathWidgetCodeGenerator : public FPCodeGenerator
   protected:
     InputPathWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     InputPathWidgetCodeGenerator(const InputPathWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const InputPathWidgetCodeGenerator&) = delete;               // Move assignment Not Implemented
+    InputPathWidgetCodeGenerator(InputPathWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    InputPathWidgetCodeGenerator& operator=(const InputPathWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    InputPathWidgetCodeGenerator& operator=(InputPathWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/IntVec3WidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/IntVec3WidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class IntVec3WidgetCodeGenerator : public FPCodeGenerator
   protected:
     IntVec3WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     IntVec3WidgetCodeGenerator(const IntVec3WidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const IntVec3WidgetCodeGenerator&) = delete;             // Move assignment Not Implemented
+    IntVec3WidgetCodeGenerator(IntVec3WidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    IntVec3WidgetCodeGenerator& operator=(const IntVec3WidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    IntVec3WidgetCodeGenerator& operator=(IntVec3WidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/IntWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/IntWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class IntWidgetCodeGenerator : public FPCodeGenerator
   protected:
     IntWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     IntWidgetCodeGenerator(const IntWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const IntWidgetCodeGenerator&) = delete;         // Move assignment Not Implemented
+    IntWidgetCodeGenerator(IntWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    IntWidgetCodeGenerator& operator=(const IntWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    IntWidgetCodeGenerator& operator=(IntWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/LinkedBooleanWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/LinkedBooleanWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class LinkedBooleanWidgetCodeGenerator : public FPCodeGenerator
   protected:
     LinkedBooleanWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     LinkedBooleanWidgetCodeGenerator(const LinkedBooleanWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const LinkedBooleanWidgetCodeGenerator&) = delete;                   // Move assignment Not Implemented
+    LinkedBooleanWidgetCodeGenerator(LinkedBooleanWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    LinkedBooleanWidgetCodeGenerator& operator=(const LinkedBooleanWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    LinkedBooleanWidgetCodeGenerator& operator=(LinkedBooleanWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/MultiAttributeMatrixSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/MultiAttributeMatrixSelectionWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class MultiAttributeMatrixSelectionWidgetCodeGenerator : public FPCodeGenerator
   protected:
     MultiAttributeMatrixSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     MultiAttributeMatrixSelectionWidgetCodeGenerator(const MultiAttributeMatrixSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MultiAttributeMatrixSelectionWidgetCodeGenerator&) = delete;                                   // Move assignment Not Implemented
+    MultiAttributeMatrixSelectionWidgetCodeGenerator(MultiAttributeMatrixSelectionWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    MultiAttributeMatrixSelectionWidgetCodeGenerator& operator=(const MultiAttributeMatrixSelectionWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    MultiAttributeMatrixSelectionWidgetCodeGenerator& operator=(MultiAttributeMatrixSelectionWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/MultiDataArraySelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/MultiDataArraySelectionWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class MultiDataArraySelectionWidgetCodeGenerator : public FPCodeGenerator
   protected:
     MultiDataArraySelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     MultiDataArraySelectionWidgetCodeGenerator(const MultiDataArraySelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const MultiDataArraySelectionWidgetCodeGenerator&) = delete;                             // Move assignment Not Implemented
+    MultiDataArraySelectionWidgetCodeGenerator(MultiDataArraySelectionWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    MultiDataArraySelectionWidgetCodeGenerator& operator=(const MultiDataArraySelectionWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    MultiDataArraySelectionWidgetCodeGenerator& operator=(MultiDataArraySelectionWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/NumericTypeWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/NumericTypeWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class NumericTypeWidgetCodeGenerator : public FPCodeGenerator
   protected:
     NumericTypeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     NumericTypeWidgetCodeGenerator(const NumericTypeWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const NumericTypeWidgetCodeGenerator&) = delete;                 // Move assignment Not Implemented
+    NumericTypeWidgetCodeGenerator(NumericTypeWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    NumericTypeWidgetCodeGenerator& operator=(const NumericTypeWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    NumericTypeWidgetCodeGenerator& operator=(NumericTypeWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/OutputFileWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/OutputFileWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class OutputFileWidgetCodeGenerator : public FPCodeGenerator
   protected:
     OutputFileWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     OutputFileWidgetCodeGenerator(const OutputFileWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const OutputFileWidgetCodeGenerator&) = delete;                // Move assignment Not Implemented
+    OutputFileWidgetCodeGenerator(OutputFileWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    OutputFileWidgetCodeGenerator& operator=(const OutputFileWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    OutputFileWidgetCodeGenerator& operator=(OutputFileWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/OutputPathWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/OutputPathWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class OutputPathWidgetCodeGenerator : public FPCodeGenerator
   protected:
     OutputPathWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     OutputPathWidgetCodeGenerator(const OutputPathWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const OutputPathWidgetCodeGenerator&) = delete;                // Move assignment Not Implemented
+    OutputPathWidgetCodeGenerator(OutputPathWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    OutputPathWidgetCodeGenerator& operator=(const OutputPathWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    OutputPathWidgetCodeGenerator& operator=(OutputPathWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/ParagraphWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ParagraphWidgetCodeGenerator.h
@@ -62,8 +62,10 @@ public:
 protected:
   ParagraphWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-private:
+public:
   ParagraphWidgetCodeGenerator(const ParagraphWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ParagraphWidgetCodeGenerator&);                        // Move assignment Not Implemented
+  ParagraphWidgetCodeGenerator(ParagraphWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+  ParagraphWidgetCodeGenerator& operator=(const ParagraphWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+  ParagraphWidgetCodeGenerator& operator=(ParagraphWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/PreflightUpdatedValueWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/PreflightUpdatedValueWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class PreflightUpdatedValueWidgetCodeGenerator : public FPCodeGenerator
   protected:
     PreflightUpdatedValueWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     PreflightUpdatedValueWidgetCodeGenerator(const PreflightUpdatedValueWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const PreflightUpdatedValueWidgetCodeGenerator&) = delete;                           // Move assignment Not Implemented
+    PreflightUpdatedValueWidgetCodeGenerator(PreflightUpdatedValueWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    PreflightUpdatedValueWidgetCodeGenerator& operator=(const PreflightUpdatedValueWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    PreflightUpdatedValueWidgetCodeGenerator& operator=(PreflightUpdatedValueWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/RangeWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/RangeWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class RangeWidgetCodeGenerator : public FPCodeGenerator
   protected:
     RangeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     RangeWidgetCodeGenerator(const RangeWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const RangeWidgetCodeGenerator&) = delete;           // Move assignment Not Implemented
+    RangeWidgetCodeGenerator(RangeWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    RangeWidgetCodeGenerator& operator=(const RangeWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    RangeWidgetCodeGenerator& operator=(RangeWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/ScalarTypeWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ScalarTypeWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class ScalarTypeWidgetCodeGenerator : public FPCodeGenerator
   protected:
     ScalarTypeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     ScalarTypeWidgetCodeGenerator(const ScalarTypeWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ScalarTypeWidgetCodeGenerator&) = delete;                // Move assignment Not Implemented
+    ScalarTypeWidgetCodeGenerator(ScalarTypeWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    ScalarTypeWidgetCodeGenerator& operator=(const ScalarTypeWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    ScalarTypeWidgetCodeGenerator& operator=(ScalarTypeWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/SecondOrderPolynomialWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/SecondOrderPolynomialWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class SecondOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
   protected:
     SecondOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     SecondOrderPolynomialWidgetCodeGenerator(const SecondOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SecondOrderPolynomialWidgetCodeGenerator&) = delete;                           // Move assignment Not Implemented
+    SecondOrderPolynomialWidgetCodeGenerator(SecondOrderPolynomialWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    SecondOrderPolynomialWidgetCodeGenerator& operator=(const SecondOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    SecondOrderPolynomialWidgetCodeGenerator& operator=(SecondOrderPolynomialWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/SeparatorWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/SeparatorWidgetCodeGenerator.h
@@ -66,8 +66,10 @@ class SeparatorWidgetCodeGenerator : public FPCodeGenerator
   protected:
     SeparatorWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     SeparatorWidgetCodeGenerator(const SeparatorWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const SeparatorWidgetCodeGenerator&) = delete;               // Move assignment Not Implemented
+    SeparatorWidgetCodeGenerator(SeparatorWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    SeparatorWidgetCodeGenerator& operator=(const SeparatorWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    SeparatorWidgetCodeGenerator& operator=(SeparatorWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/StringWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/StringWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class StringWidgetCodeGenerator : public FPCodeGenerator
   protected:
     StringWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     StringWidgetCodeGenerator(const StringWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StringWidgetCodeGenerator&) = delete;            // Move assignment Not Implemented
+    StringWidgetCodeGenerator(StringWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    StringWidgetCodeGenerator& operator=(const StringWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    StringWidgetCodeGenerator& operator=(StringWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/CodeGenerators/ThirdOrderPolynomialWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ThirdOrderPolynomialWidgetCodeGenerator.h
@@ -64,8 +64,10 @@ class ThirdOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
   protected:
     ThirdOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
 
-  private:
+  public:
     ThirdOrderPolynomialWidgetCodeGenerator(const ThirdOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented
-    void operator=(const ThirdOrderPolynomialWidgetCodeGenerator&) = delete;                          // Move assignment Not Implemented
+    ThirdOrderPolynomialWidgetCodeGenerator(ThirdOrderPolynomialWidgetCodeGenerator&&) = delete;      // Move Constructor Not Implemented
+    ThirdOrderPolynomialWidgetCodeGenerator& operator=(const ThirdOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Assignment Not Implemented
+    ThirdOrderPolynomialWidgetCodeGenerator& operator=(ThirdOrderPolynomialWidgetCodeGenerator&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/DevHelper.h
+++ b/Source/DevHelper/DevHelper.h
@@ -72,7 +72,10 @@ class DevHelper : public QMainWindow, public Ui::DevHelper
     void readWindowSettings(QtSSettings& prefs);
     void writeWindowSettings(QtSSettings& prefs);
 
-    DevHelper(const DevHelper&);    // Copy Constructor Not Implemented
-    void operator=(const DevHelper&); // Move assignment Not Implemented
+  public:
+    DevHelper(const DevHelper&) = delete;            // Copy Constructor Not Implemented
+    DevHelper(DevHelper&&) = delete;                 // Move Constructor Not Implemented
+    DevHelper& operator=(const DevHelper&) = delete; // Copy Assignment Not Implemented
+    DevHelper& operator=(DevHelper&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/DevHelper/FilterMaker.h
+++ b/Source/DevHelper/FilterMaker.h
@@ -123,7 +123,10 @@ class FilterMaker : public QWidget, public Ui::FilterMaker
 
     QMap<QString, QString> getFunctionContents();
 
-    FilterMaker(const FilterMaker&);    // Copy Constructor Not Implemented
-    void operator=(const FilterMaker&); // Move assignment Not Implemented
+  public:
+    FilterMaker(const FilterMaker&) = delete;            // Copy Constructor Not Implemented
+    FilterMaker(FilterMaker&&) = delete;                 // Move Constructor Not Implemented
+    FilterMaker& operator=(const FilterMaker&) = delete; // Copy Assignment Not Implemented
+    FilterMaker& operator=(FilterMaker&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLView/AboutSIMPLView.h
+++ b/Source/SIMPLView/AboutSIMPLView.h
@@ -85,7 +85,10 @@ class AboutSIMPLView : public QDialog, private Ui::AboutSIMPLView
 
     QAction* m_CloseAction = nullptr;
 
+  public:
     AboutSIMPLView(const AboutSIMPLView&) = delete; // Copy Constructor Not Implemented
-    void operator=(const AboutSIMPLView&) = delete; // Move assignment Not Implemented
+    AboutSIMPLView(AboutSIMPLView&&) = delete;      // Move Constructor Not Implemented
+    AboutSIMPLView& operator=(const AboutSIMPLView&) = delete; // Copy Assignment Not Implemented
+    AboutSIMPLView& operator=(AboutSIMPLView&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLView/SIMPLViewApplication.h
+++ b/Source/SIMPLView/SIMPLViewApplication.h
@@ -239,7 +239,10 @@ private:
 
   int m_minSplashTime;
 
+public:
   SIMPLViewApplication(const SIMPLViewApplication&) = delete; // Copy Constructor Not Implemented
-  void operator=(const SIMPLViewApplication&);                // Move assignment Not Implemented
+  SIMPLViewApplication(SIMPLViewApplication&&) = delete;      // Move Constructor Not Implemented
+  SIMPLViewApplication& operator=(const SIMPLViewApplication&) = delete; // Copy Assignment Not Implemented
+  SIMPLViewApplication& operator=(SIMPLViewApplication&&) = delete;      // Move Assignment Not Implemented
 };
 

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -389,8 +389,11 @@ class SIMPLView_UI : public QMainWindow
      */
     PipelineModel* getPipelineModel();
 
-    SIMPLView_UI(const SIMPLView_UI&);    // Copy Constructor Not Implemented
-    void operator=(const SIMPLView_UI&);  // Move assignment Not Implemented
+  public:
+    SIMPLView_UI(const SIMPLView_UI&) = delete;            // Copy Constructor Not Implemented
+    SIMPLView_UI(SIMPLView_UI&&) = delete;                 // Move Constructor Not Implemented
+    SIMPLView_UI& operator=(const SIMPLView_UI&) = delete; // Copy Assignment Not Implemented
+    SIMPLView_UI& operator=(SIMPLView_UI&&) = delete;      // Move Assignment Not Implemented
 };
 
 

--- a/Source/SIMPLView/StatusBarWidget.h
+++ b/Source/SIMPLView/StatusBarWidget.h
@@ -118,8 +118,10 @@ class StatusBarWidget : public QFrame, private Ui::StatusBarWidget
      */
     void setupGui();
 
-  private:
+  public:
     StatusBarWidget(const StatusBarWidget&) = delete; // Copy Constructor Not Implemented
-    void operator=(const StatusBarWidget&) = delete;  // Operator '=' Not Implemented
+    StatusBarWidget(StatusBarWidget&&) = delete;      // Move Constructor Not Implemented
+    StatusBarWidget& operator=(const StatusBarWidget&) = delete; // Copy Assignment Not Implemented
+    StatusBarWidget& operator=(StatusBarWidget&&) = delete;      // Move Assignment Not Implemented
 };
 


### PR DESCRIPTION
Classes are updated to use C++11 standard '=delete' or '=default' for each of
the copy and move constructors and copy and move assignments.

Other misc formatting updates to any affected classes.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>