### PR TITLE
Use clang tidy to update codes for readability.

### DIFF
--- a/Source/SIMPLView/AboutSIMPLView.cpp
+++ b/Source/SIMPLView/AboutSIMPLView.cpp
@@ -79,10 +79,9 @@ AboutSIMPLView::AboutSIMPLView(QWidget* parent) :
 AboutSIMPLView::~AboutSIMPLView()
 {
 #if defined (Q_OS_MAC)
-  if (m_CloseAction != nullptr)
-  {
+
     delete m_CloseAction;
-  }
+
 #endif
 }
 

--- a/Source/SIMPLView/SIMPLViewApplication.cpp
+++ b/Source/SIMPLView/SIMPLViewApplication.cpp
@@ -382,7 +382,7 @@ QVector<ISIMPLibPlugin*> SIMPLViewApplication::loadPlugins()
   // THIS IS A VERY IMPORTANT LINE: It will register all the known filters in the dream3d library. This
   // will NOT however get filters from plugins. We are going to have to figure out how to compile filters
   // into their own plugin and load the plugins from a command line.
-  filterManager->RegisterKnownFilters(filterManager);
+  FilterManager::RegisterKnownFilters(filterManager);
 
   PluginManager* pluginManager = PluginManager::Instance();
   QList<PluginProxy::Pointer> proxies = AboutPlugins::readPluginCache();
@@ -404,13 +404,13 @@ QVector<ISIMPLibPlugin*> SIMPLViewApplication::loadPlugins()
     QString fileName = fi.fileName();
     QObject* plugin = loader->instance();
     qDebug() << "    Pointer: " << plugin << "\n";
-    if(plugin)
+    if(plugin != nullptr)
     {
       ISIMPLibPlugin* ipPlugin = qobject_cast<ISIMPLibPlugin*>(plugin);
-      if(ipPlugin)
+      if(ipPlugin != nullptr)
       {
         QString pluginName = ipPlugin->getPluginFileName();
-        if(loadingMap.value(pluginName, true) == true)
+        if(loadingMap.value(pluginName, true))
         {
           QString msg = QObject::tr("Loading Plugin %1  ").arg(fileName);
           this->m_SplashScreen->showMessage(msg, Qt::AlignVCenter | Qt::AlignRight, Qt::white);
@@ -615,7 +615,7 @@ void SIMPLViewApplication::listenShowSIMPLViewHelpTriggered()
   SVUserManualDialog::LaunchHelpDialog(helpURL);
 #else
   bool didOpen = QDesktopServices::openUrl(helpURL);
-  if(false == didOpen)
+  if(!didOpen)
   {
     QMessageBox msgBox;
     msgBox.setText(QString("Error Opening Help File"));
@@ -666,7 +666,7 @@ void SIMPLViewApplication::listenSetDataFolderTriggered()
 
   validator->setSIMPLDataDirectory(dataDir);
 
-  if (m_ActiveWindow)
+  if(m_ActiveWindow != nullptr)
   {
     m_ActiveWindow->setStatusBarMessage(tr("%1 Data Directory set successfully to '%2'.").arg(QApplication::applicationName()).arg(dataDir));
   }
@@ -697,8 +697,7 @@ void SIMPLViewApplication::checkForUpdatesAtStartup()
     QDate lastUpdateCheckDate = updatePrefs.value(UpdateCheckDialog::GetUpdateCheckKey(), QString("")).toDate();
     updatePrefs.endGroup();
 
-    QDate systemDate;
-    QDate currentDateToday = systemDate.currentDate();
+    QDate currentDateToday = QDate::currentDate();
 
     QDate dailyThreshold = lastUpdateCheckDate.addDays(1);
     QDate weeklyThreshold = lastUpdateCheckDate.addDays(7);
@@ -755,7 +754,7 @@ void SIMPLViewApplication::listenDisplayPluginInfoDialogTriggered()
   /* If any of the load checkboxes were changed, display a dialog warning
   * the user that they must restart SIMPLView to see the changes.
   */
-  if(dialog.getLoadPreferencesDidChange() == true)
+  if(dialog.getLoadPreferencesDidChange())
   {
     QMessageBox msgBox;
     msgBox.setText(QString("%1 must be restarted to allow these changes to take effect.").arg(BrandedStrings::ApplicationName));
@@ -812,7 +811,7 @@ SIMPLView_UI* SIMPLViewApplication::getNewSIMPLViewInstance()
   newInstance->setAttribute(Qt::WA_DeleteOnClose);
   newInstance->setWindowTitle("[*]Untitled Pipeline - " + BrandedStrings::ApplicationName);
 
-  if (m_ActiveWindow)
+  if(m_ActiveWindow != nullptr)
   {
     newInstance->move(m_ActiveWindow->x() + 45, m_ActiveWindow->y() + 45);
   }
@@ -852,14 +851,14 @@ void SIMPLViewApplication::listenExitApplicationTriggered()
     SIMPLView_UI* dream3dWindow = m_SIMPLViewInstances[i];
     if(nullptr != dream3dWindow)
     {
-      if(dream3dWindow->close() == false)
+      if(!dream3dWindow->close())
       {
         shouldReallyClose = false;
       }
     }
   }
 
-  if(shouldReallyClose == true)
+  if(shouldReallyClose)
   {
     quit();
   }
@@ -932,7 +931,7 @@ bool SIMPLViewApplication::event(QEvent* event)
     // This needs to be here to prevent the close event from firing twice when quitting DREAM3D from the macOS dock.
     return false;
   }
-  else if (event->type() == QEvent::FileOpen)
+  if(event->type() == QEvent::FileOpen)
   {
     QFileOpenEvent* openEvent = static_cast<QFileOpenEvent*>(event);
     QString filePath = openEvent->file();
@@ -991,7 +990,7 @@ void SIMPLViewApplication::readSettings()
   SVStyle* styles = SVStyle::Instance();
   QString themeFilePath = prefs->value("Theme File Path", QString()).toString();
   QFileInfo fi(themeFilePath);
-  if (themeFilePath.isEmpty() == false && BrandedStrings::LoadedThemeNames.contains(fi.baseName()))
+  if(!themeFilePath.isEmpty() && BrandedStrings::LoadedThemeNames.contains(fi.baseName()))
   {
     styles->loadStyleSheet(themeFilePath);
   }

--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -124,7 +124,7 @@ SIMPLView_UI::SIMPLView_UI(QWidget* parent)
 
   // Register all the known filterWidgets
   m_FilterWidgetManager = FilterWidgetManager::Instance();
-  m_FilterWidgetManager->RegisterKnownFilterWidgets();
+  FilterWidgetManager::RegisterKnownFilterWidgets();
 
   // Calls the Parent Class to do all the Widget Initialization that were created
   // using the QDesigner program
@@ -199,10 +199,8 @@ bool SIMPLView_UI::savePipeline()
     // When the file hasn't been saved before, the same functionality as a "Save As" occurs...
     return savePipelineAs();
   }
-  else
-  {
+
     filePath = windowFilePath();
-  }
 
   // Fix the separators
   filePath = QDir::toNativeSeparators(filePath);
@@ -238,7 +236,7 @@ bool SIMPLView_UI::savePipelineAs()
 {
   QString proposedFile = m_LastOpenedFilePath + QDir::separator() + "Untitled.json";
   QString filePath = QFileDialog::getSaveFileName(this, tr("Save Pipeline To File"), proposedFile, tr("Json File (*.json);;SIMPLView File (*.dream3d);;All Files (*.*)"));
-  if(true == filePath.isEmpty())
+  if(filePath.isEmpty())
   {
     return false;
   }
@@ -299,7 +297,7 @@ bool SIMPLView_UI::savePipelineAs()
 void SIMPLView_UI::activateBookmark(const QString& filePath, bool execute)
 {
   SIMPLView_UI* instance = dream3dApp->getActiveInstance();
-  if(instance != nullptr && instance->isWindowModified() == false && instance->getPipelineModel()->isEmpty())
+  if(instance != nullptr && !instance->isWindowModified() && instance->getPipelineModel()->isEmpty())
   {
     instance->openPipeline(filePath);
   }
@@ -325,7 +323,7 @@ void SIMPLView_UI::activateBookmark(const QString& filePath, bool execute)
 // -----------------------------------------------------------------------------
 void SIMPLView_UI::closeEvent(QCloseEvent* event)
 {
-  if(m_Ui->pipelineListWidget->getPipelineView()->isPipelineCurrentlyRunning() == true)
+  if(m_Ui->pipelineListWidget->getPipelineView()->isPipelineCurrentlyRunning())
   {
     QMessageBox runningPipelineBox;
     runningPipelineBox.setWindowTitle("Pipeline is Running");
@@ -673,7 +671,7 @@ void SIMPLView_UI::createSIMPLViewMenuSystem()
   m_SIMPLViewMenu->addMenu(m_MenuView);
 
   QStringList themeNames = BrandedStrings::LoadedThemeNames;
-  if (themeNames.size() > 0)  // We are not counting the Default theme when deciding whether or not to add the theme menu
+  if(!themeNames.empty()) // We are not counting the Default theme when deciding whether or not to add the theme menu
   {
     m_ThemeActionGroup = new QActionGroup(this);
     m_MenuThemes = dream3dApp->createThemeMenu(m_ThemeActionGroup, m_SIMPLViewMenu);
@@ -817,7 +815,7 @@ void SIMPLView_UI::connectDockWidgetSignalsSlots(QDockWidget* dockWidget)
 // -----------------------------------------------------------------------------
 void SIMPLView_UI::showDockWidget(QDockWidget* dockWidget)
 {
-  if (tabifiedDockWidgets(dockWidget).isEmpty() && dockWidget->toggleViewAction()->isChecked() == false)
+  if(tabifiedDockWidgets(dockWidget).isEmpty() && !dockWidget->toggleViewAction()->isChecked())
   {
     dockWidget->toggleViewAction()->trigger();
   }
@@ -897,26 +895,24 @@ void SIMPLView_UI::setLoadedPlugins(QVector<ISIMPLibPlugin*> plugins)
 QMessageBox::StandardButton SIMPLView_UI::checkDirtyDocument()
 {
 
-  if(this->isWindowModified() == true)
+  if(this->isWindowModified())
   {
     int r = QMessageBox::warning(this, BrandedStrings::ApplicationName, tr("The Pipeline has been modified.\nDo you want to save your changes?"), QMessageBox::Save | QMessageBox::Default,
                                  QMessageBox::Discard, QMessageBox::Cancel | QMessageBox::Escape);
     if(r == QMessageBox::Save)
     {
-      if(savePipeline() == true)
+      if(savePipeline())
       {
         return QMessageBox::Save;
       }
-      else
-      {
+
         return QMessageBox::Cancel;
-      }
     }
-    else if(r == QMessageBox::Discard)
+    if(r == QMessageBox::Discard)
     {
       return QMessageBox::Discard;
     }
-    else if(r == QMessageBox::Cancel)
+    if(r == QMessageBox::Cancel)
     {
       return QMessageBox::Cancel;
     }
@@ -1022,7 +1018,7 @@ void SIMPLView_UI::showFilterHelp(const QString& className)
 #else
   QUrl helpURL = URL_GENERATOR::GenerateHTMLUrl(className);
   bool didOpen = QDesktopServices::openUrl(helpURL);
-  if(false == didOpen)
+  if(!didOpen)
   {
     QMessageBox msgBox;
     msgBox.setText(QString("Error Opening Help File"));
@@ -1044,7 +1040,7 @@ void SIMPLView_UI::showFilterHelpUrl(const QUrl& helpURL)
   SVUserManualDialog::LaunchHelpDialog(helpURL);
 #else
   bool didOpen = QDesktopServices::openUrl(helpURL);
-  if(false == didOpen)
+  if(!didOpen)
   {
     QMessageBox msgBox;
     msgBox.setText(QString("Error Opening Help File"));
@@ -1116,7 +1112,7 @@ void SIMPLView_UI::setFilterInputWidget(FilterInputWidget* widget)
     return;
   }
 
-  if(m_FilterInputWidget)
+  if(m_FilterInputWidget != nullptr)
   {
     emit m_FilterInputWidget->endPathFiltering();
     emit m_FilterInputWidget->endViewPaths();
@@ -1152,10 +1148,10 @@ void SIMPLView_UI::setFilterInputWidget(FilterInputWidget* widget)
 void SIMPLView_UI::clearFilterInputWidget()
 {
   QLayoutItem* item = m_Ui->fiwFrameVLayout->takeAt(0);
-  if(item)
+  if(item != nullptr)
   {
     QWidget* w = item->widget();
-    if(w)
+    if(w != nullptr)
     {
       w->hide();
       w->setParent(nullptr);

--- a/Source/SIMPLView/main.cpp
+++ b/Source/SIMPLView/main.cpp
@@ -74,7 +74,7 @@ void InitFonts(const QStringList& fontList)
   {
     QFile res(*constIterator);
     // qDebug() << "font path: " << res.fileName();
-    if(res.open(QIODevice::ReadOnly) == false)
+    if(!res.open(QIODevice::ReadOnly))
     {
       qDebug() << "ERROR opening font resource: " << res.fileName();
     }
@@ -213,6 +213,6 @@ int main(int argc, char* argv[])
   QtSDocServer::Instance();
 #endif
 
-  int err = qtapp.exec();
+  int err = SIMPLViewApplication::exec();
   return err;
 }


### PR DESCRIPTION
clang-tidy was run with the following arguments:
-checks='-*,+readability-*,-readability-identifier-naming,modernize-use-equals-default'

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>