### PR TITLE
Default use the Lato font for the UI and remove hard coded colors

### DIFF
--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -968,9 +968,10 @@ void SIMPLView_UI::processPipelineMessage(const PipelineMessage& msg)
       m_Ui->issuesDockWidget->setVisible(true);
     }
 
-    QString text = "<span style=\" color:#000000;\" >";
-    text.append(msg.getText());
-    text.append("</span>");
+    QString text;
+    QTextStream ts(&text);
+    ts << "<a style=\"color: " << SVStyle::Instance()->getQLabel_color().name(QColor::HexRgb) << ";\" >" << msg.getText() << "</span>";
+
     m_Ui->stdOutWidget->appendText(text);
   }
 }
@@ -1203,10 +1204,7 @@ void SIMPLView_UI::setStatusBarMessage(const QString& msg)
 // -----------------------------------------------------------------------------
 void SIMPLView_UI::addStdOutputMessage(const QString& msg)
 {
-  QString text = "<span style=\" color:#000000;\" >";
-  text.append(msg);
-  text.append("</span>");
-  m_Ui->stdOutWidget->appendText(text);
+  m_Ui->stdOutWidget->appendText(msg);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLView/StyleSheetEditor.cpp
+++ b/Source/SIMPLView/StyleSheetEditor.cpp
@@ -54,8 +54,6 @@
 #include "StyleSheetEditor.h"
 #include "BrandedStrings.h"
 
-#include "SVWidgetsLib/QtSupport/QtSStyles.h"
-
 #include "ui_StyleSheetEditor.h"
 
 StyleSheetEditor::StyleSheetEditor(QWidget* parent)

--- a/Source/SIMPLView/main.cpp
+++ b/Source/SIMPLView/main.cpp
@@ -48,7 +48,6 @@
 #include "SIMPLView_UI.h"
 #include "StyleSheetEditor.h"
 
-#include "SVWidgetsLib/QtSupport/QtSStyles.h"
 #include "SVWidgetsLib/QtSupport/QtSRecentFileList.h"
 #include "SVWidgetsLib/SVWidgetsLib.h"
 #include "SVWidgetsLib/Widgets/SVStyle.h"
@@ -161,30 +160,12 @@ int main(int argc, char* argv[])
   setlocale(LC_NUMERIC, "C");
 
   // Load the default font from SIMPL
-  QString firaSansFontPath(":/SIMPL/fonts/FiraSans-Regular.ttf");
-  int id = QFontDatabase::addApplicationFont(firaSansFontPath);
+  QStringList fontList;
+  fontList << QString(":/SIMPL/fonts/FiraSans-Regular.ttf") << QString(":/SIMPL/fonts/Lato-Regular.ttf") << QString(":/SIMPL/fonts/Lato-Black.ttf") << QString(":/SIMPL/fonts/Lato-BlackItalic.ttf")
+           << QString(":/SIMPL/fonts/Lato-Bold.ttf") << QString(":/SIMPL/fonts/Lato-BoldItalic.ttf") << QString(":/SIMPL/fonts/Lato-Hairline.ttf") << QString(":/SIMPL/fonts/Lato-HairlineItalic.ttf")
+           << QString(":/SIMPL/fonts/Lato-Italic.ttf") << QString(":/SIMPL/fonts/Lato-Light.ttf") << QString(":/SIMPL/fonts/Lato-LightItalic.ttf");
 
-  /* On Linux builds this will always return -1 */
-  if(id >= 0)
-  {
-    QString family = QFontDatabase::applicationFontFamilies(id).at(0);
-
-    QFont defaultFont(family);
-    defaultFont.setPixelSize(12);
-    qApp->setFont(defaultFont);
-//    qDebug() << "Default Font Loaded: " << firaSansFontPath;
-  }
-  else
-  {
-    qDebug() << "ERROR LOADING DEFAULT FONT: " << firaSansFontPath;
-  }
-
-  // This is the single standard font that ships with the open-source version
-  {
-    QStringList fontList;
-    fontList << firaSansFontPath;
-    InitFonts(fontList);
-  }
+  InitFonts(fontList);
 
   // Init any extra fonts that are needed by specialized versions of SIMPLView
   InitFonts(BrandedStrings::ExtraFonts);


### PR DESCRIPTION
+ Lato font is included inside of SIMPL
+ Remove places where color #000000 was used.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>