### PR TITLE
feature/MessagesRedesign

### DIFF
--- a/Source/DevHelper/Template/Filter/Filter.cpp.in
+++ b/Source/DevHelper/Template/Filter/Filter.cpp.in
@@ -84,14 +84,14 @@ void @ClassName@::execute()
   {
     QString ss = QObject::tr("Some warning message");
     setWarningCondition(-88888888);
-    notifyWarningMessage(getHumanLabel(), ss, getWarningCondition());
+    notifyWarningMessage(ss, getWarningCondition());
   }
 
   if (getErrorCondition() < 0)
   {
     QString ss = QObject::tr("Some error message");
     setErrorCondition(-99999999);
-    notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
+    notifyErrorMessage(ss, getErrorCondition());
     return;
   }
 

--- a/Source/DevHelper/Template/Filter/Filter.cpp.in
+++ b/Source/DevHelper/Template/Filter/Filter.cpp.in
@@ -30,8 +30,8 @@
 // -----------------------------------------------------------------------------
 void @ClassName@::initialize()
 {
-  setErrorCondition(0);
-  setWarningCondition(0);
+  clearErrorCondition();
+  clearWarningCondition();
   setCancel(false);
 }
 
@@ -50,8 +50,8 @@ void @ClassName@::setupFilterParameters()
 // -----------------------------------------------------------------------------
 void @ClassName@::dataCheck()
 {
-  setErrorCondition(0);
-  setWarningCondition(0);
+  clearErrorCondition();
+  clearWarningCondition();
   @DataCheckContents@
 }
 

--- a/Source/DevHelper/Template/Filter/Filter.cpp.in
+++ b/Source/DevHelper/Template/Filter/Filter.cpp.in
@@ -83,15 +83,15 @@ void @ClassName@::execute()
   if (getWarningCondition() < 0)
   {
     QString ss = QObject::tr("Some warning message");
-    setWarningCondition(-88888888);
-    notifyWarningMessage(ss, getWarningCondition());
+    setWarningCondition(-88888888); // @@WARNING_CODE@@-88888888@@
+    @@SET_WARNING_CONDITION@@(@@getWarningCondition()@@, ss);
   }
 
   if (getErrorCondition() < 0)
   {
     QString ss = QObject::tr("Some error message");
-    setErrorCondition(-99999999);
-    notifyErrorMessage(ss, getErrorCondition());
+    setErrorCondition(-99999999); // @@ERROR_CODE@@-99999999@@
+    @@SET_ERROR_CONDITION@@(@@getErrorCondition()@@, ss);
     return;
   }
 

--- a/Source/DevHelper/Template/Filter/Filter.cpp.in
+++ b/Source/DevHelper/Template/Filter/Filter.cpp.in
@@ -83,13 +83,15 @@ void @ClassName@::execute()
   if (getWarningCondition() < 0)
   {
     QString ss = QObject::tr("Some warning message");
-    notifyWarningMessage("", ss, -88888888);
+    setWarningCondition(-88888888);
+    notifyWarningMessage(getHumanLabel(), ss, getWarningCondition());
   }
 
   if (getErrorCondition() < 0)
   {
     QString ss = QObject::tr("Some error message");
-    notifyErrorMessage("", ss, -99999999);
+    setErrorCondition(-99999999);
+    notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
     return;
   }
 

--- a/Source/DevHelper/Template/Filter/Filter.cpp.in
+++ b/Source/DevHelper/Template/Filter/Filter.cpp.in
@@ -83,15 +83,13 @@ void @ClassName@::execute()
   if (getWarningCondition() < 0)
   {
     QString ss = QObject::tr("Some warning message");
-    setWarningCondition(-88888888);
-    notifyWarningMessage(getHumanLabel(), ss, getWarningCondition());
+    notifyWarningMessage("", ss, -88888888);
   }
 
   if (getErrorCondition() < 0)
   {
     QString ss = QObject::tr("Some error message");
-    setErrorCondition(-99999999);
-    notifyErrorMessage(getHumanLabel(), ss, getErrorCondition());
+    notifyErrorMessage("", ss, -99999999);
     return;
   }
 

--- a/Source/DevHelper/Template/Filter/Filter.cpp.in
+++ b/Source/DevHelper/Template/Filter/Filter.cpp.in
@@ -30,8 +30,8 @@
 // -----------------------------------------------------------------------------
 void @ClassName@::initialize()
 {
-  clearErrorCondition();
-  clearWarningCondition();
+  clearErrorCode();
+  clearWarningCode();
   setCancel(false);
 }
 
@@ -50,8 +50,8 @@ void @ClassName@::setupFilterParameters()
 // -----------------------------------------------------------------------------
 void @ClassName@::dataCheck()
 {
-  clearErrorCondition();
-  clearWarningCondition();
+  clearErrorCode();
+  clearWarningCode();
   @DataCheckContents@
 }
 

--- a/Source/DevHelper/Template/Filter/Filter.cpp.in
+++ b/Source/DevHelper/Template/Filter/Filter.cpp.in
@@ -83,15 +83,13 @@ void @ClassName@::execute()
   if (getWarningCondition() < 0)
   {
     QString ss = QObject::tr("Some warning message");
-    setWarningCondition(-88888888); // @@WARNING_CODE@@-88888888@@
-    @@SET_WARNING_CONDITION@@(@@getWarningCondition()@@, ss);
+    setWarningCondition(-88888888, ss);
   }
 
   if (getErrorCondition() < 0)
   {
     QString ss = QObject::tr("Some error message");
-    setErrorCondition(-99999999); // @@ERROR_CODE@@-99999999@@
-    @@SET_ERROR_CONDITION@@(@@getErrorCondition()@@, ss);
+    setErrorCondition(-99999999, ss);
     return;
   }
 

--- a/Source/SIMPLView/CMakeLists.txt
+++ b/Source/SIMPLView/CMakeLists.txt
@@ -83,6 +83,7 @@ set(SIMPLView_SRCS
   ${SIMPLView_SOURCE_DIR}/SIMPLView_UI.cpp
   ${SIMPLView_SOURCE_DIR}/AboutSIMPLView.cpp
   ${SIMPLView_SOURCE_DIR}/SIMPLViewApplication.cpp
+  ${SIMPLView_SOURCE_DIR}/SIMPLViewUIMessageHandler.cpp
   ${SIMPLView_SOURCE_DIR}/StyleSheetEditor.cpp
   )
 
@@ -91,6 +92,7 @@ set(SIMPLView_SRCS
 set(SIMPLView_HDRS
   ${SIMPLView_SOURCE_DIR}/SIMPLViewConstants.h
   ${BrandedSIMPLView_DIR}/BrandedStrings.h
+  ${SIMPLView_SOURCE_DIR}/SIMPLViewUIMessageHandler.h
 )
 
 #------------------------------------------------------------------

--- a/Source/SIMPLView/SIMPLViewUIMessageHandler.cpp
+++ b/Source/SIMPLView/SIMPLViewUIMessageHandler.cpp
@@ -1,0 +1,121 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "SIMPLViewUIMessageHandler.h"
+
+#include "SIMPLib/Messages/FilterProgressMessage.h"
+#include "SIMPLib/Messages/FilterStatusMessage.h"
+#include "SIMPLib/Messages/PipelineProgressMessage.h"
+#include "SIMPLib/Messages/PipelineStatusMessage.h"
+
+#include "SIMPLView/SIMPLView_UI.h"
+#include "SVWidgetsLib/Widgets/SVStyle.h"
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+SIMPLViewUIMessageHandler::SIMPLViewUIMessageHandler(SIMPLView_UI* uiWidget)
+: m_UIWidget(uiWidget)
+{
+
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void SIMPLViewUIMessageHandler::processMessage(FilterStatusMessage* msg) const
+{
+  QString statusMessage = msg->generateMessageString();
+
+  if(nullptr != m_UIWidget->statusBar())
+  {
+    m_UIWidget->statusBar()->showMessage(statusMessage);
+  }
+
+  statusMessage.prepend("      ");
+  appendStatusMessageToPipelineOutput(statusMessage);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void SIMPLViewUIMessageHandler::processMessage(PipelineProgressMessage* msg) const
+{
+  float progValue = static_cast<float>(msg->getProgressValue()) / 100;
+  m_UIWidget->m_Ui->pipelineListWidget->setProgressValue(progValue);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void SIMPLViewUIMessageHandler::processMessage(PipelineStatusMessage* msg) const
+{
+  QString statusMessage = msg->generateMessageString();
+
+  if(nullptr != m_UIWidget->statusBar())
+  {
+    m_UIWidget->statusBar()->showMessage(statusMessage);
+  }
+
+  appendStatusMessageToPipelineOutput(statusMessage);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void SIMPLViewUIMessageHandler::appendStatusMessageToPipelineOutput(const QString &statusMessage) const
+{
+  // Allow status messages to open the standard output widget
+  if(SIMPLView::DockWidgetSettings::HideDockSetting::OnStatusAndError == StandardOutputWidget::GetHideDockSetting())
+  {
+    m_UIWidget->m_Ui->stdOutDockWidget->setVisible(true);
+  }
+
+  // Allow status messages to open the issuesDockWidget as well
+  if(SIMPLView::DockWidgetSettings::HideDockSetting::OnStatusAndError == IssuesWidget::GetHideDockSetting())
+  {
+    m_UIWidget->m_Ui->issuesDockWidget->setVisible(true);
+  }
+
+//  QString text;
+//  QTextStream ts(&text);
+//  ts << "<a style=\"color: " << SVStyle::Instance()->getQLabel_color().name(QColor::HexRgb) << ";\" >" << statusMessage << "</span>";
+
+  m_UIWidget->m_Ui->stdOutWidget->appendText(statusMessage);
+}
+
+

--- a/Source/SIMPLView/SIMPLViewUIMessageHandler.cpp
+++ b/Source/SIMPLView/SIMPLViewUIMessageHandler.cpp
@@ -55,7 +55,7 @@ SIMPLViewUIMessageHandler::SIMPLViewUIMessageHandler(SIMPLView_UI* uiWidget)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void SIMPLViewUIMessageHandler::processMessage(FilterStatusMessage* msg) const
+void SIMPLViewUIMessageHandler::processMessage(const FilterStatusMessage* msg) const
 {
   QString statusMessage = msg->generateMessageString();
 
@@ -71,7 +71,7 @@ void SIMPLViewUIMessageHandler::processMessage(FilterStatusMessage* msg) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void SIMPLViewUIMessageHandler::processMessage(PipelineProgressMessage* msg) const
+void SIMPLViewUIMessageHandler::processMessage(const PipelineProgressMessage* msg) const
 {
   float progValue = static_cast<float>(msg->getProgressValue()) / 100;
   m_UIWidget->m_Ui->pipelineListWidget->setProgressValue(progValue);
@@ -80,7 +80,7 @@ void SIMPLViewUIMessageHandler::processMessage(PipelineProgressMessage* msg) con
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void SIMPLViewUIMessageHandler::processMessage(PipelineStatusMessage* msg) const
+void SIMPLViewUIMessageHandler::processMessage(const PipelineStatusMessage* msg) const
 {
   QString statusMessage = msg->generateMessageString();
 

--- a/Source/SIMPLView/SIMPLViewUIMessageHandler.cpp
+++ b/Source/SIMPLView/SIMPLViewUIMessageHandler.cpp
@@ -33,8 +33,6 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#pragma once
-
 #include "SIMPLViewUIMessageHandler.h"
 
 #include "SIMPLib/Messages/FilterProgressMessage.h"

--- a/Source/SIMPLView/SIMPLViewUIMessageHandler.h
+++ b/Source/SIMPLView/SIMPLViewUIMessageHandler.h
@@ -1,42 +1,42 @@
 /* ============================================================================
-* Copyright (c) 2009-2016 BlueQuartz Software, LLC
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* Redistributions of source code must retain the above copyright notice, this
-* list of conditions and the following disclaimer.
-*
-* Redistributions in binary form must reproduce the above copyright notice, this
-* list of conditions and the following disclaimer in the documentation and/or
-* other materials provided with the distribution.
-*
-* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
-* contributors may be used to endorse or promote products derived from this software
-* without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* The code contained herein was partially funded by the followig contracts:
-*    United States Air Force Prime Contract FA8650-07-D-5800
-*    United States Air Force Prime Contract FA8650-10-D-5210
-*    United States Prime Contract Navy N00173-07-C-2068
-*
-* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ * Copyright (c) 2009-2016 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #pragma once
 
-#include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Messages/AbstractMessageHandler.h"
+#include "SIMPLib/SIMPLib.h"
 
 class SIMPLView_UI;
 class AbstractStatusMessage;
@@ -47,38 +47,36 @@ class AbstractStatusMessage;
  */
 class SIMPLib_EXPORT SIMPLViewUIMessageHandler : public AbstractMessageHandler
 {
-  public:
-    explicit SIMPLViewUIMessageHandler(SIMPLView_UI* uiWidget);
+public:
+  explicit SIMPLViewUIMessageHandler(SIMPLView_UI* uiWidget);
 
-    /**
-     * @brief Sets the SIMPLView_UI status bar and appends the standard output widget with
-     * incoming FilterStatusMessage's status message.
-     * @param msg
-     */
-    void processMessage(const FilterStatusMessage* msg) const override;
+  /**
+   * @brief Sets the SIMPLView_UI status bar and appends the standard output widget with
+   * incoming FilterStatusMessage's status message.
+   * @param msg
+   */
+  void processMessage(const FilterStatusMessage* msg) const override;
 
-    /**
-     * @brief Sets the SIMPLView_UI progress bar with the incoming PipelineProgressMessage's
-     * progress value.
-     * @param msg
-     */
-    void processMessage(const PipelineProgressMessage* msg) const override;
+  /**
+   * @brief Sets the SIMPLView_UI progress bar with the incoming PipelineProgressMessage's
+   * progress value.
+   * @param msg
+   */
+  void processMessage(const PipelineProgressMessage* msg) const override;
 
-    /**
-     * @brief Sets the SIMPLView_UI status bar and appends the standard output widget with
-     * incoming PipelineStatusMessage's status message.
-     * @param msg
-     */
-    void processMessage(const PipelineStatusMessage* msg) const override;
+  /**
+   * @brief Sets the SIMPLView_UI status bar and appends the standard output widget with
+   * incoming PipelineStatusMessage's status message.
+   * @param msg
+   */
+  void processMessage(const PipelineStatusMessage* msg) const override;
 
-  private:
-    SIMPLView_UI* m_UIWidget = nullptr;
+private:
+  SIMPLView_UI* m_UIWidget = nullptr;
 
-    /**
-     * @brief processStatusMessage
-     * @param msg
-     */
-    void appendStatusMessageToPipelineOutput(const QString &statusMessage) const;
+  /**
+   * @brief processStatusMessage
+   * @param msg
+   */
+  void appendStatusMessageToPipelineOutput(const QString& statusMessage) const;
 };
-
-

--- a/Source/SIMPLView/SIMPLViewUIMessageHandler.h
+++ b/Source/SIMPLView/SIMPLViewUIMessageHandler.h
@@ -1,0 +1,81 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "SIMPLib/SIMPLib.h"
+#include "SIMPLib/Messages/AbstractMessageHandler.h"
+
+class SIMPLView_UI;
+class AbstractStatusMessage;
+
+/**
+ * @class SIMPLViewUIMessageHandler SIMPLViewUIMessageHandler.h DREAM3DLib/Common/SIMPLViewUIMessageHandler.h
+ * @brief This is the Message handler for the issues widget.  It is responsible for loading the issues table with new messages.
+ */
+class SIMPLib_EXPORT SIMPLViewUIMessageHandler : public AbstractMessageHandler
+{
+  public:
+    explicit SIMPLViewUIMessageHandler(SIMPLView_UI* uiWidget);
+
+    /**
+     * @brief processMessage
+     * @param msg
+     */
+    void processMessage(FilterStatusMessage* msg) const override;
+
+    /**
+     * @brief processMessage
+     * @param msg
+     */
+    void processMessage(PipelineProgressMessage* msg) const override;
+
+    /**
+     * @brief processMessage
+     * @param msg
+     */
+    void processMessage(PipelineStatusMessage* msg) const override;
+
+  private:
+    SIMPLView_UI* m_UIWidget = nullptr;
+
+    /**
+     * @brief processStatusMessage
+     * @param msg
+     */
+    void appendStatusMessageToPipelineOutput(const QString &statusMessage) const;
+};
+
+

--- a/Source/SIMPLView/SIMPLViewUIMessageHandler.h
+++ b/Source/SIMPLView/SIMPLViewUIMessageHandler.h
@@ -42,8 +42,8 @@ class SIMPLView_UI;
 class AbstractStatusMessage;
 
 /**
- * @class SIMPLViewUIMessageHandler SIMPLViewUIMessageHandler.h DREAM3DLib/Common/SIMPLViewUIMessageHandler.h
- * @brief This is the Message handler for the issues widget.  It is responsible for loading the issues table with new messages.
+ * @brief This message handler is used by SIMPLView_UI to display filter and pipeline status messages in the status bar
+ * and in the Pipeline Output dock widget.  It is also used to display pipeline progress in the progress bar.
  */
 class SIMPLib_EXPORT SIMPLViewUIMessageHandler : public AbstractMessageHandler
 {

--- a/Source/SIMPLView/SIMPLViewUIMessageHandler.h
+++ b/Source/SIMPLView/SIMPLViewUIMessageHandler.h
@@ -54,19 +54,19 @@ class SIMPLib_EXPORT SIMPLViewUIMessageHandler : public AbstractMessageHandler
      * @brief processMessage
      * @param msg
      */
-    void processMessage(FilterStatusMessage* msg) const override;
+    void processMessage(const FilterStatusMessage* msg) const override;
 
     /**
      * @brief processMessage
      * @param msg
      */
-    void processMessage(PipelineProgressMessage* msg) const override;
+    void processMessage(const PipelineProgressMessage* msg) const override;
 
     /**
      * @brief processMessage
      * @param msg
      */
-    void processMessage(PipelineStatusMessage* msg) const override;
+    void processMessage(const PipelineStatusMessage* msg) const override;
 
   private:
     SIMPLView_UI* m_UIWidget = nullptr;

--- a/Source/SIMPLView/SIMPLViewUIMessageHandler.h
+++ b/Source/SIMPLView/SIMPLViewUIMessageHandler.h
@@ -51,19 +51,22 @@ class SIMPLib_EXPORT SIMPLViewUIMessageHandler : public AbstractMessageHandler
     explicit SIMPLViewUIMessageHandler(SIMPLView_UI* uiWidget);
 
     /**
-     * @brief processMessage
+     * @brief Sets the SIMPLView_UI status bar and appends the standard output widget with
+     * incoming FilterStatusMessage's status message.
      * @param msg
      */
     void processMessage(const FilterStatusMessage* msg) const override;
 
     /**
-     * @brief processMessage
+     * @brief Sets the SIMPLView_UI progress bar with the incoming PipelineProgressMessage's
+     * progress value.
      * @param msg
      */
     void processMessage(const PipelineProgressMessage* msg) const override;
 
     /**
-     * @brief processMessage
+     * @brief Sets the SIMPLView_UI status bar and appends the standard output widget with
+     * incoming PipelineStatusMessage's status message.
      * @param msg
      */
     void processMessage(const PipelineStatusMessage* msg) const override;

--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -930,7 +930,7 @@ void SIMPLView_UI::populateMenus(QObject* plugin)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void SIMPLView_UI::processPipelineMessage(AbstractMessage::Pointer msg)
+void SIMPLView_UI::processPipelineMessage(const AbstractMessage::Pointer& msg)
 {
   SIMPLViewUIMessageHandler msgHandler(this);
   msg->visit(&msgHandler);

--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -104,6 +104,7 @@
 #include "SIMPLView/SIMPLViewApplication.h"
 #include "SIMPLView/SIMPLViewConstants.h"
 #include "SIMPLView/SIMPLViewVersion.h"
+#include "SIMPLView/SIMPLViewUIMessageHandler.h"
 
 #include "BrandedStrings.h"
 
@@ -929,51 +930,10 @@ void SIMPLView_UI::populateMenus(QObject* plugin)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void SIMPLView_UI::processPipelineMessage(const PipelineMessage& msg)
+void SIMPLView_UI::processPipelineMessage(AbstractMessage::Pointer msg)
 {
-  if(msg.getType() == PipelineMessage::MessageType::ProgressValue)
-  {
-    float progValue = static_cast<float>(msg.getProgressValue()) / 100;
-    m_Ui->pipelineListWidget->setProgressValue(progValue);
-  }
-  else if(msg.getType() == PipelineMessage::MessageType::StatusMessageAndProgressValue)
-  {
-    float progValue = static_cast<float>(msg.getProgressValue()) / 100;
-    m_Ui->pipelineListWidget->setProgressValue(progValue);
-
-    if(nullptr != this->statusBar())
-    {
-      this->statusBar()->showMessage(msg.generateStatusString());
-    }
-  }
-  else if(msg.getType() == PipelineMessage::MessageType::StandardOutputMessage || msg.getType() == PipelineMessage::MessageType::StatusMessage)
-  {
-    if(msg.getType() == PipelineMessage::MessageType::StatusMessage)
-    {
-      if(nullptr != this->statusBar())
-      {
-        this->statusBar()->showMessage(msg.generateStatusString());
-      }
-    }
-
-    // Allow status messages to open the standard output widget
-    if(SIMPLView::DockWidgetSettings::HideDockSetting::OnStatusAndError == StandardOutputWidget::GetHideDockSetting())
-    {
-      m_Ui->stdOutDockWidget->setVisible(true);
-    }
-
-    // Allow status messages to open the issuesDockWidget as well
-    if(SIMPLView::DockWidgetSettings::HideDockSetting::OnStatusAndError == IssuesWidget::GetHideDockSetting())
-    {
-      m_Ui->issuesDockWidget->setVisible(true);
-    }
-
-    QString text;
-    QTextStream ts(&text);
-    ts << "<a style=\"color: " << SVStyle::Instance()->getQLabel_color().name(QColor::HexRgb) << ";\" >" << msg.getText() << "</span>";
-
-    m_Ui->stdOutWidget->appendText(text);
-  }
+  SIMPLViewUIMessageHandler msgHandler(this);
+  msg->visit(&msgHandler);
 }
 
 // -----------------------------------------------------------------------------

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -76,6 +76,7 @@ class PipelineModel;
 class PipelineListWidget;
 class SVPipelineViewWidget;
 class SIMPLViewMenuItems;
+class SIMPLViewUIMessageHandler;
 
 /**
 * @class SIMPLView_UI SIMPLView_UI Applications/SIMPLView/SIMPLView_UI.h
@@ -93,6 +94,8 @@ class SIMPLView_UI : public QMainWindow
   public:
     SIMPLView_UI(QWidget* parent = nullptr);
     ~SIMPLView_UI() override;
+
+    friend SIMPLViewUIMessageHandler;
 
     /**
      * @brief eventFilter
@@ -282,7 +285,7 @@ class SIMPLView_UI : public QMainWindow
      * @brief processPipelineMessage
      * @param msg
      */
-    void processPipelineMessage(const PipelineMessage& msg);
+    void processPipelineMessage(AbstractMessage::Pointer msg);
 
     /**
     * @brief setFilterInputWidget

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -285,7 +285,7 @@ class SIMPLView_UI : public QMainWindow
      * @brief processPipelineMessage
      * @param msg
      */
-    void processPipelineMessage(AbstractMessage::Pointer msg);
+    void processPipelineMessage(const AbstractMessage::Pointer& msg);
 
     /**
     * @brief setFilterInputWidget


### PR DESCRIPTION
* Replacing PipelineMessage API with an AbstractMessage superclass and subclasses for every type of message. This eliminates the need for the MessageType enumeration.

* Implementing a new, cleaner and more reusable API that observers can implement to be able to process specific types of messages.  Take a look at the IssuesWidget and IssuesWidgetMessageHandler for a good example of this.  Observers can decide which types of messages they are interested in by subclassing the AbstractMessageHandler class and reimplement the appropriate processMessage() methods.

* Passing AbstractMessages from observable object to observer object using a shared pointer instead of by value. This allows observers to store the messages with all the relevant subclass data if they prefer.

* Eliminating the use of humanLabel in Observable's and AbstractFilter's notify****Message method parameters. In AbstractFilter, these methods already set the human label into the message.

* It is no longer necessary to use setErrorCondition() or setWarningCondition() outside of the notify****Message methods. The notify methods will automatically set the condition to the code that is passed in.

* Filters that emit progress messages while they are in an executing pipeline have their progress values automatically converted into overall pipeline progress values and re-emitted as pipeline progress messages. This allows filters to update the overall progress of the pipeline while they are running. Check out FilterPipelineMessageHandler at the top of the FilterPipeline implementation file.