### PR TITLE
Fixed filter parameter category in DevHelper

### DIFF
--- a/Source/DevHelper/CodeGenerators/AttributeMatrixCreationWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/AttributeMatrixCreationWidgetCodeGenerator.cpp
@@ -39,7 +39,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AttributeMatrixCreationWidgetCodeGenerator::AttributeMatrixCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+AttributeMatrixCreationWidgetCodeGenerator::AttributeMatrixCreationWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataArrayPath")
 {
 }

--- a/Source/DevHelper/CodeGenerators/AttributeMatrixCreationWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/AttributeMatrixCreationWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class AttributeMatrixCreationWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new AttributeMatrixCreationWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -66,7 +66,7 @@ class AttributeMatrixCreationWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    AttributeMatrixCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    AttributeMatrixCreationWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     AttributeMatrixCreationWidgetCodeGenerator(const AttributeMatrixCreationWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/AttributeMatrixSelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/AttributeMatrixSelectionWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AttributeMatrixSelectionWidgetCodeGenerator::AttributeMatrixSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+AttributeMatrixSelectionWidgetCodeGenerator::AttributeMatrixSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataArrayPath")
 {
 }

--- a/Source/DevHelper/CodeGenerators/AttributeMatrixSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/AttributeMatrixSelectionWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class AttributeMatrixSelectionWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new AttributeMatrixSelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class AttributeMatrixSelectionWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    AttributeMatrixSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    AttributeMatrixSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     AttributeMatrixSelectionWidgetCodeGenerator(const AttributeMatrixSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/AxisAngleWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/AxisAngleWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AxisAngleWidgetCodeGenerator::AxisAngleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+AxisAngleWidgetCodeGenerator::AxisAngleWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "AxisAngleInput_t")
 {
 }

--- a/Source/DevHelper/CodeGenerators/AxisAngleWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/AxisAngleWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class AxisAngleWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new AxisAngleWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -70,7 +70,7 @@ class AxisAngleWidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    AxisAngleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    AxisAngleWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     AxisAngleWidgetCodeGenerator(const AxisAngleWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/BooleanWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/BooleanWidgetCodeGenerator.cpp
@@ -39,7 +39,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-BooleanWidgetCodeGenerator::BooleanWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+BooleanWidgetCodeGenerator::BooleanWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "bool", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/BooleanWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/BooleanWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class BooleanWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new BooleanWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class BooleanWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    BooleanWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    BooleanWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     BooleanWidgetCodeGenerator(const BooleanWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/ChoiceWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/ChoiceWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ChoiceWidgetCodeGenerator::ChoiceWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+ChoiceWidgetCodeGenerator::ChoiceWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "int", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/ChoiceWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ChoiceWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class ChoiceWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new ChoiceWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class ChoiceWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    ChoiceWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    ChoiceWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     ChoiceWidgetCodeGenerator(const ChoiceWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/ComparisonSelectionAdvancedWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/ComparisonSelectionAdvancedWidgetCodeGenerator.cpp
@@ -39,7 +39,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ComparisonSelectionAdvancedWidgetCodeGenerator::ComparisonSelectionAdvancedWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+ComparisonSelectionAdvancedWidgetCodeGenerator::ComparisonSelectionAdvancedWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "ComparisonInputs")
 {
 }

--- a/Source/DevHelper/CodeGenerators/ComparisonSelectionAdvancedWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ComparisonSelectionAdvancedWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class ComparisonSelectionAdvancedWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new ComparisonSelectionAdvancedWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -70,7 +70,7 @@ class ComparisonSelectionAdvancedWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    ComparisonSelectionAdvancedWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    ComparisonSelectionAdvancedWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     ComparisonSelectionAdvancedWidgetCodeGenerator(const ComparisonSelectionAdvancedWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/ComparisonSelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/ComparisonSelectionWidgetCodeGenerator.cpp
@@ -39,7 +39,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ComparisonSelectionWidgetCodeGenerator::ComparisonSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+ComparisonSelectionWidgetCodeGenerator::ComparisonSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "ComparisonInputs")
 {
 }

--- a/Source/DevHelper/CodeGenerators/ComparisonSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ComparisonSelectionWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class ComparisonSelectionWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new ComparisonSelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -70,7 +70,7 @@ class ComparisonSelectionWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    ComparisonSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    ComparisonSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     ComparisonSelectionWidgetCodeGenerator(const ComparisonSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/ConstrainedDoubleWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/ConstrainedDoubleWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ConstrainedDoubleWidgetCodeGenerator::ConstrainedDoubleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+ConstrainedDoubleWidgetCodeGenerator::ConstrainedDoubleWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "double", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/ConstrainedDoubleWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ConstrainedDoubleWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class ConstrainedDoubleWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new ConstrainedDoubleWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class ConstrainedDoubleWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    ConstrainedDoubleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    ConstrainedDoubleWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     ConstrainedDoubleWidgetCodeGenerator(const ConstrainedDoubleWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/ConstrainedIntWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/ConstrainedIntWidgetCodeGenerator.cpp
@@ -39,7 +39,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ConstrainedIntWidgetCodeGenerator::ConstrainedIntWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+ConstrainedIntWidgetCodeGenerator::ConstrainedIntWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "int32_t", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/ConstrainedIntWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ConstrainedIntWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class ConstrainedIntWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new ConstrainedIntWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class ConstrainedIntWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    ConstrainedIntWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    ConstrainedIntWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     ConstrainedIntWidgetCodeGenerator(const ConstrainedIntWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DataArrayCreationWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DataArrayCreationWidgetCodeGenerator.cpp
@@ -39,7 +39,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataArrayCreationWidgetCodeGenerator::DataArrayCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DataArrayCreationWidgetCodeGenerator::DataArrayCreationWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataArrayPath")
 {
 }

--- a/Source/DevHelper/CodeGenerators/DataArrayCreationWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataArrayCreationWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class DataArrayCreationWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DataArrayCreationWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class DataArrayCreationWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DataArrayCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DataArrayCreationWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DataArrayCreationWidgetCodeGenerator(const DataArrayCreationWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DataArraySelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DataArraySelectionWidgetCodeGenerator.cpp
@@ -39,7 +39,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataArraySelectionWidgetCodeGenerator::DataArraySelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DataArraySelectionWidgetCodeGenerator::DataArraySelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataArrayPath")
 {
 }

--- a/Source/DevHelper/CodeGenerators/DataArraySelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataArraySelectionWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class DataArraySelectionWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DataArraySelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class DataArraySelectionWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DataArraySelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DataArraySelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DataArraySelectionWidgetCodeGenerator(const DataArraySelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DataContainerArrayProxyWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DataContainerArrayProxyWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataContainerArrayProxyWidgetCodeGenerator::DataContainerArrayProxyWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DataContainerArrayProxyWidgetCodeGenerator::DataContainerArrayProxyWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataContainerArrayProxy")
 {
 }

--- a/Source/DevHelper/CodeGenerators/DataContainerArrayProxyWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerArrayProxyWidgetCodeGenerator.h
@@ -52,7 +52,7 @@ class DataContainerArrayProxyWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DataContainerArrayProxyWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -69,7 +69,7 @@ class DataContainerArrayProxyWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DataContainerArrayProxyWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DataContainerArrayProxyWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DataContainerArrayProxyWidgetCodeGenerator(const DataContainerArrayProxyWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DataContainerCreationWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DataContainerCreationWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataContainerCreationWidgetCodeGenerator::DataContainerCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DataContainerCreationWidgetCodeGenerator::DataContainerCreationWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataArrayPath")
 {
 }

--- a/Source/DevHelper/CodeGenerators/DataContainerCreationWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerCreationWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class DataContainerCreationWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DataContainerCreationWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class DataContainerCreationWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DataContainerCreationWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DataContainerCreationWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DataContainerCreationWidgetCodeGenerator(const DataContainerCreationWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DataContainerGridSelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DataContainerGridSelectionWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataContainerGridSelectionWidgetCodeGenerator::DataContainerGridSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DataContainerGridSelectionWidgetCodeGenerator::DataContainerGridSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataArrayPath")
 {
 }

--- a/Source/DevHelper/CodeGenerators/DataContainerGridSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerGridSelectionWidgetCodeGenerator.h
@@ -47,7 +47,7 @@ public:
   using ConstWeakPointer = std::weak_ptr<const Self>;
   static Pointer NullPointer();
 
-  static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+  static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
   {
     Pointer sharedPtr(new DataContainerGridSelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
     return sharedPtr;
@@ -64,7 +64,7 @@ public:
   QList<QString> generateCPPIncludes() override;
 
 protected:
-  DataContainerGridSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+  DataContainerGridSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
 public:
   DataContainerGridSelectionWidgetCodeGenerator(const DataContainerGridSelectionWidgetCodeGenerator&) = delete;            // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DataContainerReaderWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DataContainerReaderWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataContainerReaderWidgetCodeGenerator::DataContainerReaderWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DataContainerReaderWidgetCodeGenerator::DataContainerReaderWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataContainerArrayProxy")
 {
 }

--- a/Source/DevHelper/CodeGenerators/DataContainerReaderWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerReaderWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class DataContainerReaderWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DataContainerReaderWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -70,7 +70,7 @@ class DataContainerReaderWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DataContainerReaderWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DataContainerReaderWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DataContainerReaderWidgetCodeGenerator(const DataContainerReaderWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DataContainerSelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DataContainerSelectionWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataContainerSelectionWidgetCodeGenerator::DataContainerSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DataContainerSelectionWidgetCodeGenerator::DataContainerSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DataArrayPath")
 {
 }

--- a/Source/DevHelper/CodeGenerators/DataContainerSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DataContainerSelectionWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class DataContainerSelectionWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DataContainerSelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class DataContainerSelectionWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DataContainerSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DataContainerSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DataContainerSelectionWidgetCodeGenerator(const DataContainerSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DoubleWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DoubleWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DoubleWidgetCodeGenerator::DoubleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DoubleWidgetCodeGenerator::DoubleWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "double", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/DoubleWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DoubleWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class DoubleWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DoubleWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -70,7 +70,7 @@ class DoubleWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DoubleWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DoubleWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DoubleWidgetCodeGenerator(const DoubleWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DynamicChoiceWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DynamicChoiceWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DynamicChoiceWidgetCodeGenerator::DynamicChoiceWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DynamicChoiceWidgetCodeGenerator::DynamicChoiceWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "int32_t", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/DynamicChoiceWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DynamicChoiceWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class DynamicChoiceWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DynamicChoiceWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class DynamicChoiceWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DynamicChoiceWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DynamicChoiceWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DynamicChoiceWidgetCodeGenerator(const DynamicChoiceWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/DynamicTableWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/DynamicTableWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DynamicTableWidgetCodeGenerator::DynamicTableWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+DynamicTableWidgetCodeGenerator::DynamicTableWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "DynamicTableData")
 {
 }

--- a/Source/DevHelper/CodeGenerators/DynamicTableWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/DynamicTableWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class DynamicTableWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new DynamicTableWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -70,7 +70,7 @@ class DynamicTableWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    DynamicTableWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    DynamicTableWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     DynamicTableWidgetCodeGenerator(const DynamicTableWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/FPCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/FPCodeGenerator.cpp
@@ -40,23 +40,23 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-FPCodeGenerator::FPCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue, QString varType, bool podType)
-: m_PropertyName(std::move(propertyName))
-, m_HumanLabel(std::move(humanLabel))
-, m_Category(std::move(category))
-, m_InitValue(std::move(initValue))
-, m_VariableType(std::move(varType))
+FPCodeGenerator::FPCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue, const QString& varType, bool podType)
+: m_PropertyName(propertyName)
+, m_HumanLabel(humanLabel)
+, m_Category(category)
+, m_InitValue(initValue)
+, m_VariableType(varType)
 , m_PODType(podType)
 {
-  if (category == "Parameter")
+  if(m_Category == "Parameter")
   {
     m_Category = "FilterParameter::Parameter";
   }
-  else if (category == "Required Arrays")
+  else if(m_Category == "Required Arrays")
   {
     m_Category = "FilterParameter::RequiredArray";
   }
-  else if (category == "Created Arrays")
+  else if(m_Category == "Created Arrays")
   {
     m_Category = "FilterParameter::CreatedArray";
   }
@@ -67,9 +67,9 @@ FPCodeGenerator::FPCodeGenerator(QString humanLabel, QString propertyName, QStri
 }
 
 // -----------------------------------------------------------------------------
-FPCodeGenerator::Pointer FPCodeGenerator::New(QString humanLabel, QString propertyName, QString category, QString initValue)
+FPCodeGenerator::Pointer FPCodeGenerator::New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 {
-  Pointer sharedPtr(new FPCodeGenerator(std::move(humanLabel), std::move(propertyName), std::move(category), std::move(initValue), "UNKNOWN", false));
+  Pointer sharedPtr(new FPCodeGenerator(humanLabel, propertyName, category, initValue, "UNKNOWN", false));
   return sharedPtr;
 }
 

--- a/Source/DevHelper/CodeGenerators/FPCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FPCodeGenerator.h
@@ -66,7 +66,7 @@ class FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue);
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
     virtual ~FPCodeGenerator();
 
@@ -96,7 +96,7 @@ class FPCodeGenerator
     virtual QString generateFilterParameters();
 
   protected:
-    FPCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue, QString varType, bool podType = false);
+    FPCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue, const QString& varType, bool podType = false);
 
     QString getPropertyName();
     QString getHumanLabel();

--- a/Source/DevHelper/CodeGenerators/FileListInfoWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/FileListInfoWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-FileListInfoWidgetCodeGenerator::FileListInfoWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+FileListInfoWidgetCodeGenerator::FileListInfoWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "FileListInfo_t")
 {
 }

--- a/Source/DevHelper/CodeGenerators/FileListInfoWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FileListInfoWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class FileListInfoWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new FileListInfoWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class FileListInfoWidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    FileListInfoWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    FileListInfoWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     FileListInfoWidgetCodeGenerator(const FileListInfoWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/FloatVec2WidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/FloatVec2WidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-FloatVec2WidgetCodeGenerator::FloatVec2WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+FloatVec2WidgetCodeGenerator::FloatVec2WidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "FloatVec2_t")
 {
 }

--- a/Source/DevHelper/CodeGenerators/FloatVec2WidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FloatVec2WidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class FloatVec2WidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new FloatVec2WidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class FloatVec2WidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    FloatVec2WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    FloatVec2WidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     FloatVec2WidgetCodeGenerator(const FloatVec2WidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/FloatVec3WidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/FloatVec3WidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-FloatVec3WidgetCodeGenerator::FloatVec3WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+FloatVec3WidgetCodeGenerator::FloatVec3WidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "FloatVec3Type")
 {
 }

--- a/Source/DevHelper/CodeGenerators/FloatVec3WidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FloatVec3WidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class FloatVec3WidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new FloatVec3WidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class FloatVec3WidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    FloatVec3WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    FloatVec3WidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     FloatVec3WidgetCodeGenerator(const FloatVec3WidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/FloatWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/FloatWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-FloatWidgetCodeGenerator::FloatWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+FloatWidgetCodeGenerator::FloatWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "float", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/FloatWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FloatWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class FloatWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new FloatWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class FloatWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    FloatWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    FloatWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     FloatWidgetCodeGenerator(const FloatWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/FourthOrderPolynomialWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/FourthOrderPolynomialWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-FourthOrderPolynomialWidgetCodeGenerator::FourthOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+FourthOrderPolynomialWidgetCodeGenerator::FourthOrderPolynomialWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "Float4thOrderPoly_t")
 {
 }

--- a/Source/DevHelper/CodeGenerators/FourthOrderPolynomialWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/FourthOrderPolynomialWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class FourthOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new FourthOrderPolynomialWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class FourthOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    FourthOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    FourthOrderPolynomialWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     FourthOrderPolynomialWidgetCodeGenerator(const FourthOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/GenerateColorTableWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/GenerateColorTableWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-GenerateColorTableWidgetCodeGenerator::GenerateColorTableWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+GenerateColorTableWidgetCodeGenerator::GenerateColorTableWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QString")
 {
 }

--- a/Source/DevHelper/CodeGenerators/GenerateColorTableWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/GenerateColorTableWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class GenerateColorTableWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new GenerateColorTableWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -70,7 +70,7 @@ class GenerateColorTableWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    GenerateColorTableWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    GenerateColorTableWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     GenerateColorTableWidgetCodeGenerator(const GenerateColorTableWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/InputFileWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/InputFileWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-InputFileWidgetCodeGenerator::InputFileWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+InputFileWidgetCodeGenerator::InputFileWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QString")
 {
 }

--- a/Source/DevHelper/CodeGenerators/InputFileWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/InputFileWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class InputFileWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new InputFileWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class InputFileWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    InputFileWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    InputFileWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     InputFileWidgetCodeGenerator(const InputFileWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/InputPathWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/InputPathWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-InputPathWidgetCodeGenerator::InputPathWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+InputPathWidgetCodeGenerator::InputPathWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QString")
 {
 }

--- a/Source/DevHelper/CodeGenerators/InputPathWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/InputPathWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class InputPathWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new InputPathWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class InputPathWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    InputPathWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    InputPathWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     InputPathWidgetCodeGenerator(const InputPathWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/IntVec2WidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/IntVec2WidgetCodeGenerator.cpp
@@ -38,7 +38,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec2WidgetCodeGenerator::IntVec2WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+IntVec2WidgetCodeGenerator::IntVec2WidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "IntVec2Type")
 {
 }

--- a/Source/DevHelper/CodeGenerators/IntVec2WidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/IntVec2WidgetCodeGenerator.h
@@ -49,7 +49,7 @@ public:
   using ConstWeakPointer = std::weak_ptr<const Self>;
   static Pointer NullPointer();
 
-  static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+  static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
   {
     Pointer sharedPtr(new IntVec2WidgetCodeGenerator(humanLabel, propertyName, category, initValue));
     return sharedPtr;
@@ -66,7 +66,7 @@ public:
   virtual QList<QString> generateHIncludes();
 
 protected:
-  IntVec2WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+  IntVec2WidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
 public:
   IntVec2WidgetCodeGenerator(const IntVec2WidgetCodeGenerator&) = delete;            // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/IntVec3WidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/IntVec3WidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3WidgetCodeGenerator::IntVec3WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+IntVec3WidgetCodeGenerator::IntVec3WidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "IntVec3Type")
 {
 }

--- a/Source/DevHelper/CodeGenerators/IntVec3WidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/IntVec3WidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class IntVec3WidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new IntVec3WidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class IntVec3WidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    IntVec3WidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    IntVec3WidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     IntVec3WidgetCodeGenerator(const IntVec3WidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/IntWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/IntWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntWidgetCodeGenerator::IntWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+IntWidgetCodeGenerator::IntWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "int32_t", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/IntWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/IntWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class IntWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new IntWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class IntWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    IntWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    IntWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     IntWidgetCodeGenerator(const IntWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/LinkedBooleanWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/LinkedBooleanWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-LinkedBooleanWidgetCodeGenerator::LinkedBooleanWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+LinkedBooleanWidgetCodeGenerator::LinkedBooleanWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "bool", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/LinkedBooleanWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/LinkedBooleanWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class LinkedBooleanWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new LinkedBooleanWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class LinkedBooleanWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    LinkedBooleanWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    LinkedBooleanWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     LinkedBooleanWidgetCodeGenerator(const LinkedBooleanWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/MontageSelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/MontageSelectionWidgetCodeGenerator.cpp
@@ -38,7 +38,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-MontageSelectionWidgetCodeGenerator::MontageSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+MontageSelectionWidgetCodeGenerator::MontageSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "MontageSelection")
 {
 }

--- a/Source/DevHelper/CodeGenerators/MontageSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/MontageSelectionWidgetCodeGenerator.h
@@ -49,7 +49,7 @@ public:
   using ConstWeakPointer = std::weak_ptr<const Self>;
   static Pointer NullPointer();
 
-  static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+  static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
   {
     Pointer sharedPtr(new MontageSelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
     return sharedPtr;
@@ -66,7 +66,7 @@ public:
   virtual QList<QString> generateHIncludes();
 
 protected:
-  MontageSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+  MontageSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
 public:
   MontageSelectionWidgetCodeGenerator(const MontageSelectionWidgetCodeGenerator&) = delete;            // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/MultiAttributeMatrixSelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/MultiAttributeMatrixSelectionWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-MultiAttributeMatrixSelectionWidgetCodeGenerator::MultiAttributeMatrixSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+MultiAttributeMatrixSelectionWidgetCodeGenerator::MultiAttributeMatrixSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QVector<DataArrayPath>")
 {
 }

--- a/Source/DevHelper/CodeGenerators/MultiAttributeMatrixSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/MultiAttributeMatrixSelectionWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class MultiAttributeMatrixSelectionWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new MultiAttributeMatrixSelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class MultiAttributeMatrixSelectionWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    MultiAttributeMatrixSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    MultiAttributeMatrixSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     MultiAttributeMatrixSelectionWidgetCodeGenerator(const MultiAttributeMatrixSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/MultiDataArraySelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/MultiDataArraySelectionWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-MultiDataArraySelectionWidgetCodeGenerator::MultiDataArraySelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+MultiDataArraySelectionWidgetCodeGenerator::MultiDataArraySelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QVector<DataArrayPath>")
 {
 }

--- a/Source/DevHelper/CodeGenerators/MultiDataArraySelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/MultiDataArraySelectionWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class MultiDataArraySelectionWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new MultiDataArraySelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class MultiDataArraySelectionWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    MultiDataArraySelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    MultiDataArraySelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     MultiDataArraySelectionWidgetCodeGenerator(const MultiDataArraySelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/MultiDataContainerSelectionWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/MultiDataContainerSelectionWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-MultiDataContainerSelectionWidgetCodeGenerator::MultiDataContainerSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+MultiDataContainerSelectionWidgetCodeGenerator::MultiDataContainerSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QStringList")
 {
 }

--- a/Source/DevHelper/CodeGenerators/MultiDataContainerSelectionWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/MultiDataContainerSelectionWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class MultiDataContainerSelectionWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new MultiDataContainerSelectionWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class MultiDataContainerSelectionWidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    MultiDataContainerSelectionWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    MultiDataContainerSelectionWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     MultiDataContainerSelectionWidgetCodeGenerator(const MultiDataContainerSelectionWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/NumericTypeWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/NumericTypeWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-NumericTypeWidgetCodeGenerator::NumericTypeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+NumericTypeWidgetCodeGenerator::NumericTypeWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "SIMPL::NumericTypes::Type", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/NumericTypeWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/NumericTypeWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class NumericTypeWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new NumericTypeWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class NumericTypeWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    NumericTypeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    NumericTypeWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     NumericTypeWidgetCodeGenerator(const NumericTypeWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/OutputFileWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/OutputFileWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OutputFileWidgetCodeGenerator::OutputFileWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+OutputFileWidgetCodeGenerator::OutputFileWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QString")
 {
 }

--- a/Source/DevHelper/CodeGenerators/OutputFileWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/OutputFileWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class OutputFileWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new OutputFileWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class OutputFileWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    OutputFileWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    OutputFileWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     OutputFileWidgetCodeGenerator(const OutputFileWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/OutputPathWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/OutputPathWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OutputPathWidgetCodeGenerator::OutputPathWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+OutputPathWidgetCodeGenerator::OutputPathWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QString")
 {
 }

--- a/Source/DevHelper/CodeGenerators/OutputPathWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/OutputPathWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class OutputPathWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new OutputPathWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class OutputPathWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    OutputPathWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    OutputPathWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     OutputPathWidgetCodeGenerator(const OutputPathWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/ParagraphWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/ParagraphWidgetCodeGenerator.cpp
@@ -38,7 +38,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ParagraphWidgetCodeGenerator::ParagraphWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+ParagraphWidgetCodeGenerator::ParagraphWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QString")
 {
 }

--- a/Source/DevHelper/CodeGenerators/ParagraphWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ParagraphWidgetCodeGenerator.h
@@ -49,7 +49,7 @@ public:
   using ConstWeakPointer = std::weak_ptr<const Self>;
   static Pointer NullPointer();
 
-  static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+  static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
   {
     Pointer sharedPtr(new ParagraphWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
     return sharedPtr;
@@ -66,7 +66,7 @@ public:
   QList<QString> generateCPPIncludes() override;
 
 protected:
-  ParagraphWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+  ParagraphWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
 public:
   ParagraphWidgetCodeGenerator(const ParagraphWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/PreflightUpdatedValueWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/PreflightUpdatedValueWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-PreflightUpdatedValueWidgetCodeGenerator::PreflightUpdatedValueWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+PreflightUpdatedValueWidgetCodeGenerator::PreflightUpdatedValueWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QString")
 {
 }

--- a/Source/DevHelper/CodeGenerators/PreflightUpdatedValueWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/PreflightUpdatedValueWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class PreflightUpdatedValueWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new PreflightUpdatedValueWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class PreflightUpdatedValueWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    PreflightUpdatedValueWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    PreflightUpdatedValueWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     PreflightUpdatedValueWidgetCodeGenerator(const PreflightUpdatedValueWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/RangeWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/RangeWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-RangeWidgetCodeGenerator::RangeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+RangeWidgetCodeGenerator::RangeWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "FPRangePair")
 {
 }

--- a/Source/DevHelper/CodeGenerators/RangeWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/RangeWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class RangeWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new RangeWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class RangeWidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    RangeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    RangeWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     RangeWidgetCodeGenerator(const RangeWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/ScalarTypeWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/ScalarTypeWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ScalarTypeWidgetCodeGenerator::ScalarTypeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+ScalarTypeWidgetCodeGenerator::ScalarTypeWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "SIMPL::NumericTypes::Type", true)
 {
 }

--- a/Source/DevHelper/CodeGenerators/ScalarTypeWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ScalarTypeWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class ScalarTypeWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new ScalarTypeWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class ScalarTypeWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    ScalarTypeWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    ScalarTypeWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     ScalarTypeWidgetCodeGenerator(const ScalarTypeWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/SecondOrderPolynomialWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/SecondOrderPolynomialWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-SecondOrderPolynomialWidgetCodeGenerator::SecondOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+SecondOrderPolynomialWidgetCodeGenerator::SecondOrderPolynomialWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "Float2ndOrderPoly_t")
 {
 }

--- a/Source/DevHelper/CodeGenerators/SecondOrderPolynomialWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/SecondOrderPolynomialWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class SecondOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new SecondOrderPolynomialWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class SecondOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    SecondOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    SecondOrderPolynomialWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     SecondOrderPolynomialWidgetCodeGenerator(const SecondOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/SeparatorWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/SeparatorWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-SeparatorWidgetCodeGenerator::SeparatorWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+SeparatorWidgetCodeGenerator::SeparatorWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "")
 {
 }

--- a/Source/DevHelper/CodeGenerators/SeparatorWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/SeparatorWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class SeparatorWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new SeparatorWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -72,7 +72,7 @@ class SeparatorWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    SeparatorWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    SeparatorWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     SeparatorWidgetCodeGenerator(const SeparatorWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/StringWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/StringWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-StringWidgetCodeGenerator::StringWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+StringWidgetCodeGenerator::StringWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "QString")
 {
 }

--- a/Source/DevHelper/CodeGenerators/StringWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/StringWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class StringWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new StringWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class StringWidgetCodeGenerator : public FPCodeGenerator
     QList<QString> generateCPPIncludes() override;
 
   protected:
-    StringWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    StringWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     StringWidgetCodeGenerator(const StringWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/CodeGenerators/ThirdOrderPolynomialWidgetCodeGenerator.cpp
+++ b/Source/DevHelper/CodeGenerators/ThirdOrderPolynomialWidgetCodeGenerator.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ThirdOrderPolynomialWidgetCodeGenerator::ThirdOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue)
+ThirdOrderPolynomialWidgetCodeGenerator::ThirdOrderPolynomialWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
 : FPCodeGenerator(humanLabel, propertyName, category, initValue, "Float3rdOrderPoly_t")
 {
 }

--- a/Source/DevHelper/CodeGenerators/ThirdOrderPolynomialWidgetCodeGenerator.h
+++ b/Source/DevHelper/CodeGenerators/ThirdOrderPolynomialWidgetCodeGenerator.h
@@ -51,7 +51,7 @@ class ThirdOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
     using ConstWeakPointer = std::weak_ptr<const Self>;
     static Pointer NullPointer();
 
-    static Pointer New(QString humanLabel, QString propertyName, QString category, QString initValue)
+    static Pointer New(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue)
     {
       Pointer sharedPtr(new ThirdOrderPolynomialWidgetCodeGenerator(humanLabel, propertyName, category, initValue));
       return sharedPtr;
@@ -68,7 +68,7 @@ class ThirdOrderPolynomialWidgetCodeGenerator : public FPCodeGenerator
     virtual QList<QString> generateHIncludes();
 
   protected:
-    ThirdOrderPolynomialWidgetCodeGenerator(QString humanLabel, QString propertyName, QString category, QString initValue);
+    ThirdOrderPolynomialWidgetCodeGenerator(const QString& humanLabel, const QString& propertyName, const QString& category, const QString& initValue);
 
   public:
     ThirdOrderPolynomialWidgetCodeGenerator(const ThirdOrderPolynomialWidgetCodeGenerator&) = delete; // Copy Constructor Not Implemented

--- a/Source/DevHelper/UI_Files/AddFilterParameter.ui
+++ b/Source/DevHelper/UI_Files/AddFilterParameter.ui
@@ -122,6 +122,15 @@
    <header>QtSFSDropLabel.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>varName</tabstop>
+  <tabstop>humanName</tabstop>
+  <tabstop>type</tabstop>
+  <tabstop>category</tabstop>
+  <tabstop>initValue</tabstop>
+  <tabstop>cancelBtn</tabstop>
+  <tabstop>addFilterParameterBtn</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
* Fixed bug where the category value in DevHelper was always "Uncategorized"
* Changed passing QString to passing const QString&
* Fixed tab stop order in AddFilterParameter widget