### PR TITLE
Embedded Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,15 +298,20 @@ configure_file(${PROJECT_RESOURCES_DIR}/SIMPLView/SIMPLViewLicense.txt
 
 # --------------------------------------------------------------------
 # Generate install rules for the text files
+set(license_install_dir "${DREAM3D_PACKAGE_DEST_PREFIX}")
+
 if(APPLE)
-  install(FILES ${SIMPLViewProj_BINARY_DIR}/SIMPLView/SIMPLViewLicense.txt 
-          DESTINATION "${DREAM3D_PACKAGE_DEST_PREFIX}/Resources"
-          COMPONENT Applications)
-else()
-  install(FILES ${SIMPLViewProj_BINARY_DIR}/SIMPLView/SIMPLViewLicense.txt 
-          DESTINATION "${DREAM3D_PACKAGE_DEST_PREFIX}"
-          COMPONENT Applications)
+  set(license_install_dir "${DREAM3D_PACKAGE_DEST_PREFIX}/Resources")
 endif()
+
+if(DREAM3D_ANACONDA)
+  set(license_install_dir "share/DREAM3D")
+endif()
+
+install(FILES ${SIMPLViewProj_BINARY_DIR}/SIMPLView/SIMPLViewLicense.txt 
+  DESTINATION ${license_install_dir}
+  COMPONENT Applications
+)
 
 #------------------------------------------------------------------------------
 # If we have not defined a "BrandedSIMPLView_DIR" then define it to the default

--- a/Resources/CPack/PackageProject.cmake
+++ b/Resources/CPack/PackageProject.cmake
@@ -15,8 +15,10 @@ if(MSVC)
     SET(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP 1)
     #SET(CMAKE_INSTALL_DEBUG_LIBRARIES OFF)
 
-    # Gather the list of system level runtime libraries
-    INCLUDE (InstallRequiredSystemLibraries)
+    if(NOT DREAM3D_DISABLE_DEPENDENCY_COPY_INSTALL_RULES)
+      # Gather the list of system level runtime libraries
+      include(InstallRequiredSystemLibraries)
+    endif()
 
     # Our own Install rule for Release builds of the MSVC runtime libs
     if(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS)

--- a/Source/SIMPLView/CMakeLists.txt
+++ b/Source/SIMPLView/CMakeLists.txt
@@ -174,6 +174,10 @@ if(UNIX AND NOT APPLE)
     set(DEST_DIR "bin")
 endif()
 
+if(DREAM3D_ANACONDA)
+  set(DEST_DIR "bin")
+endif()
+
 get_property(SIMPLPluginList GLOBAL PROPERTY SIMPLPluginList)
 file(READ "${SIMPLPluginList}" SIMPLView_PLUGINS)
 
@@ -217,6 +221,10 @@ target_include_directories(${SIMPLView_APPLICATION_NAME}
 target_include_directories(${SIMPLView_APPLICATION_NAME}
                   PUBLIC 
                     ${SIMPLView_BINARY_DIR}/__/Common)
+
+if(DREAM3D_ANACONDA)
+  target_compile_definitions(${SIMPLView_APPLICATION_NAME} PRIVATE DREAM3D_ANACONDA)
+endif()
 
 if( SIMPLView_BUILD_DOCUMENTATION)
   message(STATUS "DREAM3D_PACKAGE_DEST_PREFIX: ${DREAM3D_PACKAGE_DEST_PREFIX}")

--- a/Source/SIMPLView/SIMPLViewApplication.cpp
+++ b/Source/SIMPLView/SIMPLViewApplication.cpp
@@ -1091,7 +1091,13 @@ void SIMPLViewApplication::reloadPythonFilters()
     messageBox.setDefaultButton(QMessageBox::StandardButton::Ok);
     messageBox.exec();
   };
-  PythonLoader::loadPythonFilters(*filterManager, PythonLoader::defaultPythonFilterPaths(), pythonErrorCallback);
+  auto pythonLoadedCallback = [this](const std::string& pyClass, const std::string& filePath) {
+    for(SIMPLView_UI* instance : m_SIMPLViewInstances)
+    {
+      instance->addStdOutputMessage(QString("Loaded \"%1\" from \"%2\"").arg(QString::fromStdString(pyClass), QString::fromStdString(filePath)));
+    }
+  };
+  PythonLoader::loadPythonFilters(*filterManager, PythonLoader::defaultPythonFilterPaths(), pythonErrorCallback, pythonLoadedCallback);
 
   for(SIMPLView_UI* instance : m_SIMPLViewInstances)
   {

--- a/Source/SIMPLView/SIMPLViewApplication.cpp
+++ b/Source/SIMPLView/SIMPLViewApplication.cpp
@@ -1100,7 +1100,6 @@ void SIMPLViewApplication::reloadPythonFilters()
   for(auto&& [instance, json] : savedPipelines)
   {
     instance->deserializePipeline(json);
-    instance->clearUndoStack();
   }
 
   emit filterFactoriesUpdated();

--- a/Source/SIMPLView/SIMPLViewApplication.cpp
+++ b/Source/SIMPLView/SIMPLViewApplication.cpp
@@ -1090,11 +1090,11 @@ void SIMPLViewApplication::reloadPythonFilters()
       instance->addStdOutputMessage(QString("Loaded \"%1\" from \"%2\"").arg(QString::fromStdString(pyClass), QString::fromStdString(filePath)));
     }
   };
-  PythonLoader::loadPythonFilters(*filterManager, PythonLoader::defaultPythonFilterPaths(), pythonErrorCallback, pythonLoadedCallback);
+  size_t numLoaded = PythonLoader::loadPythonFilters(*filterManager, PythonLoader::defaultPythonFilterPaths(), pythonErrorCallback, pythonLoadedCallback);
 
   for(SIMPLView_UI* instance : m_SIMPLViewInstances)
   {
-    instance->addStdOutputMessage("Reloaded Python filters");
+    instance->addStdOutputMessage(QString("Reloaded %1 Python filters").arg(numLoaded));
   }
 
   for(auto&& [instance, json] : savedPipelines)

--- a/Source/SIMPLView/SIMPLViewApplication.cpp
+++ b/Source/SIMPLView/SIMPLViewApplication.cpp
@@ -1102,7 +1102,7 @@ void SIMPLViewApplication::reloadPythonFilters()
     instance->deserializePipeline(json);
   }
 
-  emit filterFactoriesUpdated();
+  Q_EMIT filterFactoriesUpdated();
 }
 #endif
 

--- a/Source/SIMPLView/SIMPLViewApplication.cpp
+++ b/Source/SIMPLView/SIMPLViewApplication.cpp
@@ -181,7 +181,6 @@ void delay(int seconds)
 // -----------------------------------------------------------------------------
 bool SIMPLViewApplication::initialize(int argc, char* argv[])
 {
-
   Q_UNUSED(argc)
   Q_UNUSED(argv)
   QApplication::setApplicationVersion(SIMPLib::Version::Complete());
@@ -228,12 +227,6 @@ bool SIMPLViewApplication::initialize(int argc, char* argv[])
 
   // Load application plugins.
   QVector<ISIMPLibPlugin*> plugins = loadPlugins();
-
-  FilterManager* filterManager = FilterManager::Instance();
-
-#ifdef SIMPL_EMBED_PYTHON
-  reloadPythonFilters();
-#endif
 
   // give GUI components time to update before the mainwindow is shown
   QApplication::instance()->processEvents();

--- a/Source/SIMPLView/SIMPLViewApplication.h
+++ b/Source/SIMPLView/SIMPLViewApplication.h
@@ -40,6 +40,8 @@
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMenuBar>
 
+#include "SIMPLib/SIMPLib.h"
+
 #include "SVWidgetsLib/Dialogs/UpdateCheck.h"
 
 #define dream3dApp (static_cast<SIMPLViewApplication*>(qApp))
@@ -119,6 +121,9 @@ public:
    */
   QMenu* getRecentFilesMenu();
 
+Q_SIGNALS:
+  void filterFactoriesUpdated();
+
 public Q_SLOTS:
   void listenNewInstanceTriggered();
   void listenOpenPipelineTriggered();
@@ -131,6 +136,9 @@ public Q_SLOTS:
   void listenExitApplicationTriggered();
   void listenSetDataFolderTriggered();
   void listenShowDataFolderTriggered();
+#ifdef SIMPL_EMBED_PYTHON
+  void reloadPythonFilters();
+#endif
 
   SIMPLView_UI* getNewSIMPLViewInstance();
 

--- a/Source/SIMPLView/SIMPLViewApplication.h
+++ b/Source/SIMPLView/SIMPLViewApplication.h
@@ -121,6 +121,15 @@ public:
    */
   QMenu* getRecentFilesMenu();
 
+#ifdef SIMPL_EMBED_PYTHON
+  /**
+   * @brief Enables/disables GUI elements for Python functionality based on value
+   * @param value
+   * @return
+   */
+  void setPythonGUIEnabled(bool value);
+#endif
+
 Q_SIGNALS:
   void filterFactoriesUpdated();
 
@@ -240,6 +249,11 @@ private:
   QAction* m_ActionShowDataBrowser = nullptr;
   QAction* m_ActionSetDataFolder = nullptr;
   QAction* m_ActionShowDataFolder = nullptr;
+
+#ifdef SIMPL_EMBED_PYTHON
+  QAction* m_ActionReloadPython = nullptr;
+  bool m_PythonGUIEnabled = false;
+#endif
 
   QActionGroup* m_ThemeActionGroup = nullptr;
 

--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -690,11 +690,11 @@ void SIMPLView_UI::createSIMPLViewMenuSystem()
   m_SIMPLViewMenu->addMenu(m_MenuPipeline);
   m_MenuPipeline->addAction(actionClearPipeline);
 #ifdef SIMPL_EMBED_PYTHON
-  QAction* reloadAction = new QAction("Reload Python Filters", this);
-  reloadAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_R));
-  m_MenuPipeline->addAction(reloadAction);
+  m_ActionReloadPython = new QAction("Reload Python Filters", this);
+  m_ActionReloadPython->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_R));
+  m_MenuPipeline->addAction(m_ActionReloadPython);
   SIMPLViewApplication* app = dream3dApp;
-  connect(reloadAction, &QAction::triggered, app, &SIMPLViewApplication::reloadPythonFilters);
+  connect(m_ActionReloadPython, &QAction::triggered, app, &SIMPLViewApplication::reloadPythonFilters);
 #endif
 
   // Create Help Menu
@@ -1238,3 +1238,11 @@ void SIMPLView_UI::clearPipeline(bool playAnimation)
   SVPipelineView* pipelineView = m_Ui->pipelineListWidget->getPipelineView();
   pipelineView->clearPipeline(playAnimation);
 }
+
+#ifdef SIMPL_EMBED_PYTHON
+// -----------------------------------------------------------------------------
+void SIMPLView_UI::setPythonGUIEnabled(bool value)
+{
+  m_ActionReloadPython->setEnabled(value);
+}
+#endif

--- a/Source/SIMPLView/SIMPLView_UI.cpp
+++ b/Source/SIMPLView/SIMPLView_UI.cpp
@@ -531,6 +531,8 @@ void SIMPLView_UI::setupGui()
   //  connect(m_Ui->issuesWidget, SIGNAL(tableHasErrors(bool, int, int)), m_StatusBar, SLOT(issuesTableHasErrors(bool, int, int)));
   connect(m_Ui->issuesWidget, SIGNAL(tableHasErrors(bool, int, int)), this, SLOT(issuesTableHasErrors(bool, int, int)));
   connect(m_Ui->issuesWidget, SIGNAL(showTable(bool)), m_Ui->issuesDockWidget, SLOT(setVisible(bool)));
+  connect(dream3dApp, &SIMPLViewApplication::filterFactoriesUpdated, m_Ui->filterListWidget, &FilterListToolboxWidget::loadFilterList);
+  connect(dream3dApp, &SIMPLViewApplication::filterFactoriesUpdated, m_Ui->filterLibraryWidget, &FilterLibraryToolboxWidget::refreshFilterGroups);
 
   connectDockWidgetSignalsSlots(m_Ui->bookmarksDockWidget);
   connectDockWidgetSignalsSlots(m_Ui->dataBrowserDockWidget);
@@ -687,6 +689,13 @@ void SIMPLView_UI::createSIMPLViewMenuSystem()
   // Create Pipeline Menu
   m_SIMPLViewMenu->addMenu(m_MenuPipeline);
   m_MenuPipeline->addAction(actionClearPipeline);
+#ifdef SIMPL_EMBED_PYTHON
+  QAction* reloadAction = new QAction("Reload Python Filters", this);
+  reloadAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_R));
+  m_MenuPipeline->addAction(reloadAction);
+  SIMPLViewApplication* app = dream3dApp;
+  connect(reloadAction, &QAction::triggered, app, &SIMPLViewApplication::reloadPythonFilters);
+#endif
 
   // Create Help Menu
   m_SIMPLViewMenu->addMenu(m_MenuHelp);
@@ -1170,4 +1179,62 @@ PipelineModel* SIMPLView_UI::getPipelineModel()
 {
   SVPipelineView* pipelineView = m_Ui->pipelineListWidget->getPipelineView();
   return pipelineView->getPipelineModel();
+}
+
+// -----------------------------------------------------------------------------
+bool SIMPLView_UI::hasFilterInPipeline(const QUuid& uuid) const
+{
+  SVPipelineView* pipelineView = m_Ui->pipelineListWidget->getPipelineView();
+  PipelineModel* model = pipelineView->getPipelineModel();
+  for(size_t i = 0; i < model->rowCount(); i++)
+  {
+    AbstractFilter::Pointer filter = model->filter(model->index(i, PipelineItem::Contents));
+    if(filter->getUuid() == uuid)
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+bool SIMPLView_UI::undoStackIsClear() const
+{
+  SVPipelineView* pipelineView = m_Ui->pipelineListWidget->getPipelineView();
+
+  return pipelineView->undoStackIsClear();
+}
+
+// -----------------------------------------------------------------------------
+void SIMPLView_UI::clearUndoStack()
+{
+  SVPipelineView* pipelineView = m_Ui->pipelineListWidget->getPipelineView();
+
+  pipelineView->clearUndoStack();
+}
+
+// -----------------------------------------------------------------------------
+QJsonObject SIMPLView_UI::serializePipeline() const
+{
+  SVPipelineView* pipelineView = m_Ui->pipelineListWidget->getPipelineView();
+  return pipelineView->getFilterPipeline()->toJson();
+}
+
+// -----------------------------------------------------------------------------
+void SIMPLView_UI::deserializePipeline(const QJsonObject& json)
+{
+  SVPipelineView* pipelineView = m_Ui->pipelineListWidget->getPipelineView();
+  JsonFilterParametersReader::Pointer jsonReader = JsonFilterParametersReader::New();
+  FilterPipeline::Pointer pipeline = jsonReader->readPipelineFromJson(json, pipelineView);
+  auto filterContainer = pipeline->getFilterContainer();
+  std::vector<AbstractFilter::Pointer> filters(filterContainer.cbegin(), filterContainer.cend());
+  pipelineView->addFilters(filters);
+}
+
+// -----------------------------------------------------------------------------
+void SIMPLView_UI::clearPipeline(bool playAnimation)
+{
+  SVPipelineView* pipelineView = m_Ui->pipelineListWidget->getPipelineView();
+  pipelineView->clearPipeline(playAnimation);
 }

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -215,6 +215,15 @@ public Q_SLOTS:
    */
   void listenSavePipelineAsTriggered();
 
+#ifdef SIMPL_EMBED_PYTHON
+  /**
+   * @brief Enables/disables GUI elements for Python functionality based on value
+   * @param value
+   * @return
+   */
+  void setPythonGUIEnabled(bool value);
+#endif
+
 protected:
   /**
    * @brief populateMenus This is a planned API that plugins would use to add Menus to the main application
@@ -389,6 +398,10 @@ private:
   QAction* m_ActionClearCache = nullptr;
   QAction* m_ActionSetDataFolder = nullptr;
   QAction* m_ActionShowDataFolder = nullptr;
+
+#ifdef SIMPL_EMBED_PYTHON
+  QAction* m_ActionReloadPython = nullptr;
+#endif
 
   QActionGroup* m_ThemeActionGroup = nullptr;
 

--- a/Source/SIMPLView/SIMPLView_UI.h
+++ b/Source/SIMPLView/SIMPLView_UI.h
@@ -139,6 +139,42 @@ public:
    */
   void showDockWidget(QDockWidget* dockWidget);
 
+  /**
+   * @brief Returns true if the given filter UUID is in the pipeline model
+   * @param uuid
+   * @return
+   */
+  bool hasFilterInPipeline(const QUuid& uuid) const;
+
+  /**
+   * @brief Returns true if the undo stack is clean
+   * @return
+   */
+  bool undoStackIsClear() const;
+
+  /**
+   * @brief Clears the undo stack
+   */
+  void clearUndoStack();
+
+  /**
+   * @brief Returns pipeline in json form
+   * @return
+   */
+  QJsonObject serializePipeline() const;
+
+  /**
+   * @brief Adds filters to pipeline from json
+   * @param json
+   */
+  void deserializePipeline(const QJsonObject& json);
+
+  /**
+   * @brief Clears the pipeline optionally playing the animation
+   * @param playAnimation
+   */
+  void clearPipeline(bool playAnimation);
+
 public Q_SLOTS:
   /**
    * @brief setFilterBeingDragged

--- a/Source/SIMPLView/main.cpp
+++ b/Source/SIMPLView/main.cpp
@@ -196,6 +196,7 @@ int main(int argc, char* argv[])
   if(enablePython)
   {
     qtapp.reloadPythonFilters();
+    PythonLoader::addToPythonPath(PythonLoader::defaultSIMPLPythonLibPath());
   }
 #endif
 

--- a/Source/SIMPLView/main.cpp
+++ b/Source/SIMPLView/main.cpp
@@ -217,6 +217,7 @@ int main(int argc, char* argv[])
   }
 
 #ifdef SIMPL_EMBED_PYTHON
+  qtapp.setPythonGUIEnabled(enablePython);
   if(enablePython)
   {
     qtapp.reloadPythonFilters();

--- a/Source/SIMPLView/main.cpp
+++ b/Source/SIMPLView/main.cpp
@@ -111,6 +111,30 @@ void InitStyleSheetEditor()
 // -----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
+#ifdef DREAM3D_ANACONDA
+  {
+    constexpr const char k_QT_PLUGIN_PATH[] = "QT_PLUGIN_PATH";
+    constexpr const char k_PYTHONHOME[] = "PYTHONHOME";
+    QString qtPluginPath = qgetenv(k_QT_PLUGIN_PATH);
+    QString condaPrefix = qgetenv("CONDA_PREFIX");
+    if(qtPluginPath.isEmpty() && !condaPrefix.isEmpty())
+    {
+      QString absoluteQtPluginPath = QString("%1/Library/Plugins").arg(condaPrefix);
+      if(QDir(absoluteQtPluginPath).exists())
+      {
+        qputenv(k_QT_PLUGIN_PATH, absoluteQtPluginPath.toLocal8Bit());
+      }
+    }
+
+    QString pythonHome = qgetenv(k_PYTHONHOME);
+    if(pythonHome.isEmpty() && !condaPrefix.isEmpty())
+    {
+      qputenv(k_PYTHONHOME, condaPrefix.toLocal8Bit());
+    }
+    qputenv("DREAM3D_PLUGINS_LOADED", "1");
+  }
+#endif
+
 #ifdef Q_OS_X11
   // Using motif style gives us test failures (and its ugly).
   // Using cleanlooks style gives us errors when using valgrind (Trolltech's bug #179200)


### PR DESCRIPTION
SIMPLViewApplication can now load Python filters.

Requires BlueQuartzSoftware/SIMPL#420

* Reloading Python filters
  * Clears the undo stack
    * The undo stack holds on to filters which may be from Python which may become stale on reload
  * Converts any open pipeline with Python filters into json, clears the pipeline, and then attempts to restore the pipeline from json after reloading